### PR TITLE
Fixed issue with Photo URL being too long for SQL DB

### DIFF
--- a/install/database.sql
+++ b/install/database.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `modified` DATETIME NOT NULL,
   `isAdmin` TINYINT(1) NOT NULL DEFAULT 0,
   `status` ENUM('a', 'i') NOT NULL DEFAULT 'a',
-  `photoURL` VARCHAR(255) NULL,
+  `photoURL` TEXT NULL,
   `lastLogin` DATETIME NULL,
   `recoverPass` VARCHAR(255) NULL,
   `backgroundURL` VARCHAR(255) NULL,

--- a/updatedb/updateDb.v7.8.sql
+++ b/updatedb/updateDb.v7.8.sql
@@ -6,6 +6,8 @@ SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
 ALTER TABLE `categories` 
 ADD COLUMN `allow_download` TINYINT(1) NULL DEFAULT 1;
 
+ALTER TABLE `users` CHANGE `photoURL` `photoURL` TEXT
+
 
 UPDATE configurations SET  version = '7.8', modified = now() WHERE id = 1;
 


### PR DESCRIPTION
## Issue
When using Google authentication to log in, the Photo URL was exceeding the bounds of the database field.

## Fix
Updated database creation script to use TEXT instead of varchar.  Also added update db script for current installations.