### PR TITLE
Complete sitemap for google . SEO improve

### DIFF
--- a/objects/functions.php
+++ b/objects/functions.php
@@ -2008,12 +2008,23 @@ function siteMap() {
     $_POST['sort']['created'] = "DESC";
     $rows = Video::getAllVideos(!empty($advancedCustom->showPrivateVideosOnSitemap) ? "viewableNotUnlisted" : "publicOnly");
     foreach ($rows as $value) {
-        $xml .= '   
+        $xml .= '
             <url>
                 <loc>' . Video::getLink($value['id'], $value['clean_title']) . '</loc>
-                <lastmod>' . $date . '</lastmod>
-                <changefreq>monthly</changefreq>
-                <priority>0.80</priority>
+                <video:video>
+                  <video:thumbnail_loc>' . $global['webSiteRootURL'] . 'videos/' . $value['filename'] . '.jpg</video:thumbnail_loc>
+                  <video:title>' . $value['title'] . '</video:title>
+                  <video:description>' . $value['description'] . '</video:description>
+                  <video:publication_date>' . $value['created'] . '</video:publication_date>
+                  <video:view_count>' . $value['views_count'] . '</video:view_count>
+                  <video:duration>' . $value['duration'] . '</video:duration>
+                  <video:uploader
+                     info=' . $global['webSiteRootURL'] . 'channel/' . $value['users_id'] . '>' . $value['title'] . '
+                  </video:uploader>
+                  <video:family_friendly>yes</video:family_friendly>
+                  <video:live>no</video:live>
+                  <video:requires_subscription>no</video:requires_subscription>
+                </video:video>
             </url>
             ';
     }


### PR DESCRIPTION
@DanielnetoDotCom PLEASE TAKE 5mn TO READ , Do NOT accept the pull request before correcting it .

First , I have really low knowledge of php . I managed to make the script work , but you will have to make it work properly .

The output of the sitemap looks like this for each video , in this way google will have accurate data of each element to crawl .

 ```
<url>
                <loc>http://192.168.0.170/AVideo/video/529/eg-vs-vg-incredible-game-hype-chongqing-major-dota-2?channelName=NoobFromUA</loc>
                <video:video>
                  <video:thumbnail_loc>http://192.168.0.170/AVideo/videos/_YPTuniqid_5e343e18303ef2.90675523.jpg</video:thumbnail_loc>
                  <video:title>EG vs VG - INCREDIBLE GAME HYPE! - CHONGQING MAJOR DOTA 2</video:title>
                  <video:description>Commentary by TobiWan &amp; Kyle  , this is just a description test</video:description>
                  <video:publication_date>2020-01-31 14:47:52</video:publication_date>
                  <video:view_count>8469</video:view_count>
                  <video:duration>00:23:51</video:duration>
                  <video:uploader
                     info=http://192.168.0.170/AVideo/channel/2>EG vs VG - INCREDIBLE GAME HYPE! - CHONGQING MAJOR DOTA 2
                  </video:uploader>
                  <video:family_friendly>yes</video:family_friendly>
                  <video:live>no</video:live>
                  <video:requires_subscription>no</video:requires_subscription>
                </video:video>
            </url>
```

2) Some values will not be accepted by google and other crawlers , such as `<video:duration>` , since it should be in seconds , and I have no knowlegde how to transform h,m,s into seconds .
3) `<video:requires_subscription>` , could be improved . On database we have values 0 and 1 for `only_for_paid` . Crawlers accept the values yes and no . Need to add some coding to make value 0 = no , and 1 = yes
4) `<video:tag>` This could help a lot of the video SEO , but I don't know how to get it from tags_has_video ( db table )
5) `<video:category>` Same , when I try with `' . $value['categories_id'] . ' `I get only the number , but need to display the name from categories table `[name]` . 
6) `<video:rating>` better to ignore for the moment , since the project did not focus much on it , but easly could be implemented
7) `<video:content_loc>` I ognored this option of lake of knowledge . I can make it work for my site ( since all videos are on hls ) and easly implement .m3u8 . But if a site has mixed content will need extra codes , to determine the video extension . Basically you should point the video root . Example : www.example.com/video/120/test.mp4
8) <video:player_loc> The embedding url ( ignored for now , may impact ads )
9) <video:uploader is working fine ( but no seo link ) .` channel/2` is accepted and does send you to the correct uploader , but the link has no seo . Need to pull the channelName from , table users - channelName . I don't know how to do that .
You could make it work easly with your knowledge of php .

My problem right now is that you're using a different scheme then the one needed for a video hosting project .
Getting errors : 
```
This page contains the following errors:
error on line 231 at column 27: AttValue: " or ' expected
Below is a rendering of the page up to the first error.
```

The output looking is pure html , and no organization 
![image](https://user-images.githubusercontent.com/52116577/79733896-7d142e00-82fe-11ea-8698-79b2cea31388.png)


The one needed is 
xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">

Source information : https://support.google.com/webmasters/answer/80471?hl=en&ref_topic=4581190

Thanks for reading .