### PR TITLE
Fixed text and location

### DIFF
--- a/plugin/TheaterButton/addButton.js
+++ b/plugin/TheaterButton/addButton.js
@@ -12,7 +12,7 @@ $(document).ready(function () {
             Button.apply(this, arguments);
             this.addClass('ypt-compress');
             this.addClass('vjs-button-fa-size');
-            this.controlText("Theater mode");
+            this.controlText("Default view");
             if (Cookies.get('compress') === "true") {
                 toogleEC(this);
             }

--- a/plugin/TheaterButton/addButton.js
+++ b/plugin/TheaterButton/addButton.js
@@ -22,8 +22,11 @@ $(document).ready(function () {
         }
     });
 
-// Register the new component
+// Register the new component and set the right location as FF is not having a PIP button.
     videojs.registerComponent('Theater', Theater);
-    player.getChild('controlBar').addChild('Theater', {}, getPlayerButtonIndex('CaptionsButton') + 1);
+    if (player.getChild('controlBar').getChild('PictureInPictureToggle')){
+    player.getChild('controlBar').addChild('Theater', {}, getPlayerButtonIndex('PictureInPictureToggle') + 1);
+    }  else {
+    player.getChild('controlBar').addChild('Theater', {}, getPlayerButtonIndex('fullscreenToggle') - 1);
     }, 30);
 });

--- a/plugin/TheaterButton/addButton.js
+++ b/plugin/TheaterButton/addButton.js
@@ -12,7 +12,7 @@ $(document).ready(function () {
             Button.apply(this, arguments);
             this.addClass('ypt-compress');
             this.addClass('vjs-button-fa-size');
-            this.controlText("Theater");
+            this.controlText("Theater mode");
             if (Cookies.get('compress') === "true") {
                 toogleEC(this);
             }
@@ -24,6 +24,6 @@ $(document).ready(function () {
 
 // Register the new component
     videojs.registerComponent('Theater', Theater);
-    player.getChild('controlBar').addChild('Theater', {}, getPlayerButtonIndex('RemainingTimeDisplay') + 1);
+    player.getChild('controlBar').addChild('Theater', {}, getPlayerButtonIndex('CaptionsButton') + 1);
     }, 30);
 });


### PR DESCRIPTION
The initial text was still `Theater` in compressed mode now it will start with `Default view`.
Changed also location the to be more in line with other video players. It also detects if the pip button is active as FF has no active pip button. 

- FireFox
![image](https://user-images.githubusercontent.com/31585599/82424479-89b6ae00-9a85-11ea-91ff-70bf0d154731.png)
And with Chrome it is also on the correct location.

- Chrome
![image](https://user-images.githubusercontent.com/31585599/82424589-b10d7b00-9a85-11ea-8c18-e70db33451fc.png)

- Example previous
![image](https://user-images.githubusercontent.com/31585599/82424656-c8e4ff00-9a85-11ea-8ea3-1a04aed150ed.png)

