### PR TITLE
Theater icon made to same size as other icons

### DIFF
--- a/plugin/TheaterButton/style.css
+++ b/plugin/TheaterButton/style.css
@@ -14,7 +14,7 @@ footer{
   font-variant: normal;
   text-rendering: auto;
   content: "\e900";
-  font-size: 1.1em;
+  font-size: 0.9em;
   line-height: 1.0em;
   font-family: 'videojs-theaterMode';
   font-weight: 300;
@@ -26,8 +26,8 @@ footer{
   font-variant: normal;
   text-rendering: auto;
   content: "\e901";
-  font-size: 1.4em;
-  line-height: 1.2em;
+  font-size: 0.9em;
+  line-height: 1.0em;
   font-family: 'videojs-theaterMode';
   font-weight: 300;
 }


### PR DESCRIPTION
The theater icon was to large compared with the other icons. Fixed the sizing.

- Old:
![image](https://user-images.githubusercontent.com/31585599/82494246-953bc080-9ae9-11ea-8a57-9ffb17792106.png)

- New:
![image](https://user-images.githubusercontent.com/31585599/82494193-7dfcd300-9ae9-11ea-9a38-ea68f8705a7e.png)
