### PR TITLE
NetFlix plugin: descending sort in date

### DIFF
--- a/plugin/YouPHPFlix2/view/modeFlixBody.php
+++ b/plugin/YouPHPFlix2/view/modeFlixBody.php
@@ -83,6 +83,7 @@ include $global['systemRootPath'] . 'plugin/YouPHPFlix2/view/BigVideo.php';
         }
 
         unset($_POST['sort']);
+        $_POST['sort']['created'] = "DESC";
 
         $videos = Video::getAllVideos("viewableNotUnlisted", false, true);
         if (!empty($videos)) {


### PR DESCRIPTION
When displaying the sorted by date row it should start with the newest video.

Andreas