### PR TITLE
Update restreamer.json.php

### DIFF
--- a/plugin/Live/restreamer.json.php
+++ b/plugin/Live/restreamer.json.php
@@ -167,7 +167,7 @@ function startRestream($m3u8, $restreamsDestinations, $logFile, $tries = 1) {
      * 
      */
     if (count($restreamsDestinations) > 1) {
-        $command = "{$ffmpegBinary} -i \"{$m3u8}\" ";
+        $command = "{$ffmpegBinary} -re -i \"{$m3u8}\" ";
         foreach ($restreamsDestinations as $value) {
             if(!isOpenSSLEnabled() && preg_match("/rtpms:/i", $value)){
                 error_log("Restreamer.json.php ERROR #1 FFMPEG openssl is not enabled, ignoring $value ");
@@ -180,7 +180,7 @@ function startRestream($m3u8, $restreamsDestinations, $logFile, $tries = 1) {
         if(!isOpenSSLEnabled() && preg_match("/rtpms:/i", $restreamsDestinations[0])){
             error_log("Restreamer.json.php ERROR #2 FFMPEG openssl is not enabled, ignoring {$restreamsDestinations[0]} ");
         }else{
-            $command = "ffmpeg -i \"{$m3u8}\" -max_muxing_queue_size 1024 -acodec copy -bsf:a aac_adtstoasc -vcodec copy -f flv \"{$restreamsDestinations[0]}\"";
+            $command = "ffmpeg -re -i \"{$m3u8}\" -max_muxing_queue_size 1024 -acodec copy -bsf:a aac_adtstoasc -vcodec copy -f flv \"{$restreamsDestinations[0]}\"";
         }
     }
     if(empty($command) || !preg_match("/-f flv/i", $command)){


### PR DESCRIPTION
-re is mandatory on every live-stream . Because the speed will be dancing between x0.5 and x2 . Should be fixed to real time = x1
I'm still debugging somethings , but this one is necessary .