### PR TITLE
Small database improvements.

### DIFF
--- a/install/database.sql
+++ b/install/database.sql
@@ -11,9 +11,9 @@ CREATE TABLE IF NOT EXISTS `users` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `user` VARCHAR(45) NOT NULL,
   `name` VARCHAR(45) NULL,
-  `email` VARCHAR(45) NULL,
+  `email` VARCHAR(254) NULL,
   `password` VARCHAR(145) NOT NULL,
-  `created` DATETIME NOT NULL,
+  `created` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `modified` DATETIME NOT NULL,
   `isAdmin` TINYINT(1) NOT NULL DEFAULT 0,
   `status` ENUM('a', 'i') NOT NULL DEFAULT 'a',
@@ -187,7 +187,7 @@ ENGINE = InnoDB;
 -- Table `comments`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `comments` (
-  `id` INT NOT NULL AUTO_INCREMENT,
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
   `comment` TEXT NOT NULL,
   `videos_id` INT NOT NULL,
   `users_id` INT NOT NULL,
@@ -227,7 +227,7 @@ CREATE TABLE IF NOT EXISTS `configurations` (
   `version` VARCHAR(10) NOT NULL,
   `webSiteTitle` VARCHAR(45) NOT NULL DEFAULT 'AVideo',
   `language` VARCHAR(6) NOT NULL DEFAULT 'en',
-  `contactEmail` VARCHAR(45) NOT NULL,
+  `contactEmail` VARCHAR(254) NOT NULL,
   `modified` DATETIME NOT NULL,
   `created` DATETIME NOT NULL,
   `authGoogle_id` VARCHAR(255) NULL,


### PR DESCRIPTION
- Email fields must be maxlenght 254 according to RFC https://www.ietf.org/rfc/rfc2821.txt
- I strongly recommend use always the same naming convention with the fields names: Always in lower case with "_" for split words. MySQL and linux system are case sensitive and tables and fields are files in linux...