### PR TITLE
Bug-fix (#4203).

### DIFF
--- a/objects/getTotalTodayAsync.php
+++ b/objects/getTotalTodayAsync.php
@@ -10,6 +10,6 @@ if(file_exists($lockFile)){
     return false;
 }
 file_put_contents($lockFile, 1);
-$total = Video::getTotalToday($video_id);
+$total = VideoStatistic::getTotalToday($video_id);
 file_put_contents($cacheFileName, json_encode($total));
 unlink($lockFile);


### PR DESCRIPTION
*Refer: https://github.com/WWBN/AVideo/issues/4203*
> Hi there,
>
> I am seeing the following error in my avideo.log
> PHP Fatal error: Uncaught Error: Call to undefined method Video::getTotalToday() in 
> /var/www/html/objects/getTotalTodayAsync.php:13
>
> Is this something i can ignore?
>
> thanks

The error message seems to be generated via `getTotalLastDaysAsync.php`:
```PHP
$total = Video::getTotalToday($video_id);
```

AFAICT, the method `getTotalToday` seems to be defined by `video_statistic.php`:
```PHP
    static function getTotalToday($video_id, $hour = 0, $returnArray = array()) {
```

But, the class which `getTotalToday` belongs to seems to be named as `VideoStatistic`, not `Video`:
```PHP
class VideoStatistic extends ObjectYPT {
```

Theoretically, this PR should fix the problem. But, I haven't tested extensively, so possibly, further testing may be required.