### PR TITLE
TinyMCE: Fixing sa language pack

### DIFF
--- a/view/js/tinymce/langs/sa.js
+++ b/view/js/tinymce/langs/sa.js
@@ -1,4 +1,4 @@
-tinymce.addI18n('ar',{
+tinymce.addI18n('sa',{
 "Redo": "\u0625\u0639\u0627\u062f\u0629",
 "Undo": "\u062a\u0631\u0627\u062c\u0639",
 "Cut": "\u0642\u0635",


### PR DESCRIPTION
Sorry, the `sa` language pack for TinyMCE was erroneous, the language code in the file was left to `ar` code, which is incorrect in the AVideo context. This PR fixes that.