### PR TITLE
Fix for #4272, #4211

### DIFF
--- a/objects/getImageFromFilenameAsync.php
+++ b/objects/getImageFromFilenameAsync.php
@@ -1,18 +1,22 @@
 <?php
 require_once '../videos/configuration.php';
 require_once $global['systemRootPath'] . 'objects/video.php';
-//getTotalVideosInfo($status = "viewable", $showOnlyLoggedUserVideos = false, 
+//getTotalVideosInfo($status = "viewable", $showOnlyLoggedUserVideos = false,
 //$ignoreGroup = false, $videosArrayId = array(), $getStatistcs = false)
 session_write_close();
 $filename = $argv[1];
 $type = $argv[2];
 $cacheFileName = $argv[3];
-$lockFile = $cacheFileName.".lock";
-if(file_exists($lockFile)){
+$lockFile = $cacheFileName . '.lock';
+set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+    return true;
+});
+if (file_exists($lockFile)) {
     return false;
 }
 file_put_contents($lockFile, 1);
-$total = Video::getImageFromFilename_($filename,$type);
+$total = Video::getImageFromFilename_($filename, $type);
 file_put_contents($cacheFileName, json_encode($total));
 //_error_log(__FILE__." ".$cacheFileName.": done");
 unlink($lockFile);
+restore_error_handler();


### PR DESCRIPTION
@akhilleusuggo I noticed the cited issues earlier today. Requesting your feedback/review. :-) 

I haven't yet looked more deeply into the inner workings of `getImageFromFilenameAsync.php`, but since the responses at the issues seem to describe the warnings generated as not being too serious, more primarily a cosmetic concern (e.g., maybe users don't like seeing the warnings, but it doesn't affect the overall functionality of AVideo, and the particular functionality in question needs to eventually be reworked anyway), the changes proposed by this PR should resolve those "cosmetic concerns" (effectively, just suppressing the warnings by way of introducing a temporary error handler which does nothing with those warnings/errors at the affected lines), and without imposing any further more significant changes to the codebase.

Similar idea as doing..
```PHP
<?php
@suppress_something();
```
..at the affected lines, but since doing that is generally regarded as bad practice in modern PHP programming and regarded as something that can often result in lower code quality, I've avoided that, and opted to propose this temporary error handler approach instead. ;-)
