### PR TITLE
Use Composer autoloader instead of manual loading (when possible).

### DIFF
--- a/objects/configurationUpdate.json.php
+++ b/objects/configurationUpdate.json.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
 
 header('Content-Type: application/json');
 global $global, $config;
@@ -88,7 +89,6 @@ if (!empty($_POST['faviconBase64'])) {
             "status" => 'success',
             "url" => $global['systemRootPath'] . $photoURL
         );
-        require $global['systemRootPath'] . 'objects/chrisjean/php-ico/class-php-ico.php';
 
         $sizes = array(
             array(16, 16),

--- a/objects/emailAllUsers.json.php
+++ b/objects/emailAllUsers.json.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
 
 global $global, $config;
 if (!isset($global['systemRootPath'])) {
@@ -13,7 +14,7 @@ if (!User::isAdmin()) {
 
 header('Content-Type: application/json');
 if (empty($_POST['email'])) {
-    if (!empty($_REQUEST['users_groups_id'])){
+    if (!empty($_REQUEST['users_groups_id'])) {
         $users = User::getAllUsersFromUsergroup(
             $_REQUEST['users_groups_id'],
             false,
@@ -30,7 +31,6 @@ if (empty($_POST['email'])) {
 } else {
     $users[0]["email"] = $_POST['email'];
 }
-require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';
 // send 100 emails at a time
 $mailsLimit = 100;
 

--- a/objects/functions.php
+++ b/objects/functions.php
@@ -1,8 +1,10 @@
 <?php
-$AVideoMobileAPP_UA = "AVideoMobileApp";
-$AVideoEncoder_UA = "AVideoEncoder";
-$AVideoStreamer_UA = "AVideoStreamer";
-$AVideoStorage_UA = "AVideoStorage";
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
+
+$AVideoMobileAPP_UA = 'AVideoMobileApp';
+$AVideoEncoder_UA = 'AVideoEncoder';
+$AVideoStreamer_UA = 'AVideoStreamer';
+$AVideoStorage_UA = 'AVideoStorage';
 
 function forbiddenWords($text) {
     global $global;
@@ -84,9 +86,8 @@ function parse_size($size) {
     if ($unit) {
         // Find the position of the unit in the ordered string which is the power of magnitude to multiply a kilobyte by.
         return round($size * pow(1024, stripos('bkmgtpezy', $unit[0])));
-    } else {
-        return round($size);
     }
+    return round($size);
 }
 
 function humanFileSize($size, $unit = "") {
@@ -145,7 +146,7 @@ function secondsToHumanTiming($time, $precision = 0) {
     );
 
     /**
-     * For detection propouse only
+     * For detection purposes only
      */
     __('year');
     __('month');
@@ -529,7 +530,6 @@ function sendSiteEmail($to, $subject, $message) {
     $message = createEmailMessageFromTemplate($message);
     _error_log("sendSiteEmail [" . count($to) . "] {$subject}");
     global $config, $global;
-    require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';;
     $contactEmail = $config->getContactEmail();
     $webSiteTitle = $config->getWebSiteTitle();
     try {
@@ -605,12 +605,10 @@ function createEmailMessageFromTemplate($message) {
 }
 
 function sendEmailToSiteOwner($subject, $message) {
-    global $advancedCustom;
+    global $advancedCustom, $config, $global;
     $subject = UTF8encode($subject);
     $message = UTF8encode($message);
     _error_log("sendEmailToSiteOwner {$subject}");
-    global $config, $global;
-    require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';
     $contactEmail = $config->getContactEmail();
     $webSiteTitle = $config->getWebSiteTitle();
     try {
@@ -865,7 +863,7 @@ function maxLifetime() {
         $bb_b2 = AVideoPlugin::getObjectDataIfEnabled('Blackblaze_B2');
         $secure = AVideoPlugin::getObjectDataIfEnabled('SecureVideosDirectory');
         $maxLifetime = 0;
-        if (!empty($aws_s3) && !empty($aws_s3->presignedRequestSecondsTimeout) && (empty($maxLifetime) || $aws_s3->presignedRequestSecondsTimeout < $maxLifetime) ){
+        if (!empty($aws_s3) && !empty($aws_s3->presignedRequestSecondsTimeout) && (empty($maxLifetime) || $aws_s3->presignedRequestSecondsTimeout < $maxLifetime)) {
             $maxLifetime = $aws_s3->presignedRequestSecondsTimeout;
             _error_log("maxLifetime: AWS_S3 = {$maxLifetime}");
         }
@@ -2609,7 +2607,7 @@ function siteMap() {
         _error_log("siteMap: pregreplace1 fail ");
         $newXML1 = $xml;
     }
-    if(!empty($advancedCustom->siteMapUTF8Fix)){
+    if (!empty($advancedCustom->siteMapUTF8Fix)) {
         $newXML2 = preg_replace('/&(?!#?[a-z0-9]+;)/', '&amp;', $newXML1);
         if (empty($newXML2)) {
             _error_log("siteMap: pregreplace2 fail ");
@@ -2630,7 +2628,7 @@ function siteMap() {
             _error_log("siteMap: pregreplace5 fail ");
             $newXML5 = $newXML4;
         }
-    }else{
+    } else {
         $newXML5 = $newXML1;
     }
     return $newXML5;
@@ -3714,11 +3712,7 @@ class YPTvideoObject
 
 function isToShowDuration($type) {
     $notShowTo = array('pdf', 'article', 'serie', 'zip', 'image');
-    if (in_array($type, $notShowTo)) {
-        return false;
-    } else {
-        return true;
-    }
+    return !in_array($type, $notShowTo);
 }
 
 function _dieAndLogObject($obj, $prefix = "") {
@@ -3916,8 +3910,8 @@ function URLHasLastSlash() {
 function ucname($str) {
     $str = ucwords(strtolower($str));
 
-    foreach(array('\'', '-') as $delim) {
-    if (strpos($str, $delim) !== false) {
+    foreach (array('\'', '-') as $delim) {
+        if (strpos($str, $delim) !== false) {
             $str = implode($delim, array_map('ucfirst', explode($delim, $str)));
         }
     }
@@ -4481,7 +4475,7 @@ function getPagination($total, $page = 0, $link = "", $maxVisible = 10, $infinit
         $page = getCurrentPage();
     }
 
-    $class = "";
+    $class = '';
     if (!empty($infinityScrollGetFromSelector) && !empty($infinityScrollAppendIntoSelector)) {
         $class = "infiniteScrollPagination{$uid} hidden";
     }
@@ -4540,7 +4534,7 @@ function getPagination($total, $page = 0, $link = "", $maxVisible = 10, $infinit
     return $pag;
 }
 
-function getShareMenu($title, $permaLink, $URLFriendly, $embedURL, $img, $class = "row bgWhite list-group-item menusDiv") {
+function getShareMenu($title, $permaLink, $URLFriendly, $embedURL, $img, $class = 'row bgWhite list-group-item menusDiv') {
     global $global, $advancedCustom;
     include $global['systemRootPath'] . 'objects/functiongetShareMenu.php';
 }
@@ -5120,9 +5114,9 @@ function getHeaderContentTypeFromURL($url) {
     return false;
 }
 
-function canFullScreen(){
+function canFullScreen() {
     global $doNotFullScreen;
-    if(!empty($doNotFullScreen) || isSerie() || !isVideo()){
+    if (!empty($doNotFullScreen) || isSerie() || !isVideo()) {
         return false;
     }
     return true;

--- a/objects/include_config.php
+++ b/objects/include_config.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
+
 $global['webSiteRootURL'] .= (substr($global['webSiteRootURL'], -1) == '/' ? '' : '/');
 $global['systemRootPath'] .= (substr($global['systemRootPath'], -1) == '/' ? '' : '/');
 $global['session_name'] = md5($global['systemRootPath']);
@@ -49,7 +51,7 @@ if (version_compare(PHP_VERSION, '7.3.0') >= 0) {
     setcookie('key', 'value', ['samesite' => 'None', 'secure' => true]);
 } else {
     header('Set-Cookie: cross-site-cookie=name; SameSite=None; Secure');
-    setcookie('key', 'value', time() + $config->getSession_timeout(), "/; SameSite=None; Secure");
+    setcookie('key', 'value', time() + $config->getSession_timeout(), '/; SameSite=None; Secure');
 }
 
 session_start();
@@ -59,29 +61,29 @@ if (!empty($global['enableDDOSprotection'])) {
     ddosProtection();
 }
 
-// set the reffer for aVideo
-$url1['host'] = "";
-$global["HTTP_REFERER"] = "";
-if (!empty($_SERVER["HTTP_REFERER"])) {
+// set the referrer for aVideo
+$url1['host'] = '';
+$global['HTTP_REFERER'] = '';
+if (!empty($_SERVER['HTTP_REFERER'])) {
     if ((
-        strpos($_SERVER["HTTP_REFERER"], '/video/') !== false || strpos($_SERVER["HTTP_REFERER"], '/v/') !== false
+        strpos($_SERVER['HTTP_REFERER'], '/video/') !== false || strpos($_SERVER['HTTP_REFERER'], '/v/') !== false
     ) &&
-            !empty($_SESSION["LAST_HTTP_REFERER"])) {
-        if (strpos($_SESSION["LAST_HTTP_REFERER"], 'cache/css/') !== false ||
-                strpos($_SESSION["LAST_HTTP_REFERER"], 'cache/js/') !== false ||
-                strpos($_SESSION["LAST_HTTP_REFERER"], 'cache/img/') !== false) {
-            $_SESSION["LAST_HTTP_REFERER"] = $global['webSiteRootURL'];
+            !empty($_SESSION['LAST_HTTP_REFERER'])) {
+        if (strpos($_SESSION['LAST_HTTP_REFERER'], 'cache/css/') !== false ||
+                strpos($_SESSION['LAST_HTTP_REFERER'], 'cache/js/') !== false ||
+                strpos($_SESSION['LAST_HTTP_REFERER'], 'cache/img/') !== false) {
+            $_SESSION['LAST_HTTP_REFERER'] = $global['webSiteRootURL'];
         }
-        $global["HTTP_REFERER"] = $_SESSION["LAST_HTTP_REFERER"];
-        $url1 = parse_url($global["HTTP_REFERER"]);
+        $global['HTTP_REFERER'] = $_SESSION['LAST_HTTP_REFERER'];
+        $url1 = parse_url($global['HTTP_REFERER']);
     } else {
-        $global["HTTP_REFERER"] = $_SERVER["HTTP_REFERER"];
-        $url1 = parse_url($global["HTTP_REFERER"]);
+        $global['HTTP_REFERER'] = $_SERVER['HTTP_REFERER'];
+        $url1 = parse_url($global['HTTP_REFERER']);
     }
 }
-//var_dump($global["HTTP_REFERER"]);exit;
+//var_dump($global['HTTP_REFERER']);exit;
 if (!isset($_POST['redirectUri'])) {
-    $_POST['redirectUri'] = "";
+    $_POST['redirectUri'] = '';
 }
 
 if (!empty($_POST['redirectUri']) && strpos($_POST['redirectUri'], 'logoff.php') !== false) {
@@ -93,13 +95,13 @@ if (!empty($_GET['redirectUri']) && strpos($_GET['redirectUri'], 'logoff.php') !
 
 $url2 = parse_url($global['webSiteRootURL']);
 if (!empty($url1['host']) && !empty($url2['host']) && $url1['host'] !== $url2['host']) {
-    $global["HTTP_REFERER"] = $global['webSiteRootURL'];
+    $global['HTTP_REFERER'] = $global['webSiteRootURL'];
 }
-$_SESSION["LAST_HTTP_REFERER"] = $global["HTTP_REFERER"];
-//var_dump($global["HTTP_REFERER"], $url1);exit;
+$_SESSION['LAST_HTTP_REFERER'] = $global['HTTP_REFERER'];
+//var_dump($global['HTTP_REFERER'], $url1);exit;
 
 $output = ob_get_clean();
-ob_start("ob_gzhandler");
+ob_start('ob_gzhandler');
 echo $output;
 $_SESSION['lastUpdate'] = time();
 $_SESSION['savedQuerys'] = 0;
@@ -113,17 +115,17 @@ ObjectYPT::checkSessionCacheBasedOnLastDeleteALLCacheTime();
 getDeviceID();
 allowOrigin();
 
-$baseName = basename($_SERVER["SCRIPT_FILENAME"]);
-if ($baseName !== 'xsendfile.php' && class_exists("Plugin")) {
+$baseName = basename($_SERVER['SCRIPT_FILENAME']);
+if ($baseName !== 'xsendfile.php' && class_exists('Plugin')) {
     AVideoPlugin::getStart();
 } elseif ($baseName !== 'xsendfile.php') {
     _error_log("Class Plugin Not found: {$_SERVER['REQUEST_URI']}");
 }
 if (empty($global['bodyClass'])) {
-    $global['bodyClass'] = "";
+    $global['bodyClass'] = '';
 }
 $global['allowedExtension'] = array('gif', 'jpg', 'mp4', 'webm', 'mp3', 'm4a', 'ogg', 'zip', 'm3u8');
-$advancedCustom = AVideoPlugin::getObjectData("CustomizeAdvanced");
+$advancedCustom = AVideoPlugin::getObjectData('CustomizeAdvanced');
 
 if (empty($global['disableTimeFix'])) {
     /*
@@ -135,16 +137,15 @@ if (empty($global['disableTimeFix'])) {
     $mins -= $hrs * 60;
     $offset = sprintf('%+d:%02d', $hrs * $sgn, $mins);
     $global['mysqli']->query("SET time_zone='$offset';");
-     *
      */
     ObjectYPT::setTimeZone();
 }
 
-$avideoLayout = AVideoPlugin::getObjectData("Layout");
-$avideoCustomizeUser = $advancedCustomUser = AVideoPlugin::getObjectData("CustomizeUser");
-$avideoCustomize = $customizePlugin = AVideoPlugin::getObjectData("Customize");
-$avideoPermissions = $permissionsPlugin = AVideoPlugin::getObjectData("Permissions");
-$avideoPlayerSkins = AVideoPlugin::getObjectData("PlayerSkins");
+$avideoLayout = AVideoPlugin::getObjectData('Layout');
+$avideoCustomizeUser = $advancedCustomUser = AVideoPlugin::getObjectData('CustomizeUser');
+$avideoCustomize = $customizePlugin = AVideoPlugin::getObjectData('Customize');
+$avideoPermissions = $permissionsPlugin = AVideoPlugin::getObjectData('Permissions');
+$avideoPlayerSkins = AVideoPlugin::getObjectData('PlayerSkins');
 $sitemapFile = "{$global['systemRootPath']}sitemap.xml";
 
 if (!empty($_GET['type'])) {

--- a/objects/include_phpmailer.php
+++ b/objects/include_phpmailer.php
@@ -1,8 +1,0 @@
-<?php
-$phpmailerDir = $global['systemRootPath'] . 'objects/phpmailer/';
-if(!is_dir($phpmailerDir)){
-    $phpmailerDir = $global['systemRootPath'] . 'objects/PHPMailer/';
-}
-require_once $phpmailerDir . 'phpmailer/src/PHPMailer.php';
-require_once $phpmailerDir . 'phpmailer/src/SMTP.php';
-require_once $phpmailerDir . 'phpmailer/src/Exception.php';

--- a/objects/login.json.php
+++ b/objects/login.json.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
+
 header('Access-Control-Allow-Origin: *');
 header("Access-Control-Allow-Headers: Content-Type");
 global $global, $config;
@@ -12,7 +14,7 @@ TimeLogStart($timeLog);
 
 // gettig the mobile submited value
 $inputJSON = url_get_contents('php://input');
-$input = json_decode($inputJSON, TRUE); //convert JSON into array
+$input = json_decode($inputJSON, true); //convert JSON into array
 if (!empty($input)) {
     foreach ($input as $key => $value) {
         $_POST[$key] = $value;
@@ -22,7 +24,6 @@ if (!empty($input)) {
 TimeLogEnd($timeLog, __LINE__);
 
 require_once $global['systemRootPath'] . 'videos/configuration.php';
-require_once $global['systemRootPath'] . 'objects/hybridauth/hybridauth/src/autoload.php';
 require_once $global['systemRootPath'] . 'objects/user.php';
 require_once $global['systemRootPath'] . 'objects/category.php';
 
@@ -32,13 +33,15 @@ _error_log("Start Login Request");
 
 _error_log("redirectUri: " . $_POST['redirectUri']);
 
-if (!preg_match("|^" . $global['webSiteRootURL'] . "|", $_POST['redirectUri']))
+if (!preg_match("|^" . $global['webSiteRootURL'] . "|", $_POST['redirectUri'])) {
     $_POST['redirectUri'] = $global['webSiteRootURL'];
+}
 
 _error_log("same redirectUri: " . $_POST['redirectUri']);
 
 use Hybridauth\Hybridauth;
 use Hybridauth\HttpClient;
+
 TimeLogEnd($timeLog, __LINE__);
 if (!empty($_GET['type'])) {
     if (!empty($_GET['redirectUri'])) {
@@ -130,8 +133,7 @@ if (!empty($_GET['type'])) {
         //header("Location: {$global['webSiteRootURL']}user?error=" . urlencode($e->getMessage()));
         //echo $e->getMessage();
     }
-    header('Content-Type: text/html');
-    ?>
+    header('Content-Type: text/html'); ?>
 <script>
     window.opener = self;
     if(window.name == 'loginYPT'){
@@ -212,7 +214,7 @@ $object->redirectUri = @$_POST['redirectUri'];
 if ((empty($object->redirectUri) || $object->redirectUri === $global['webSiteRootURL'])) {
     if (!empty($advancedCustomUser->afterLoginGoToMyChannel)) {
         $object->redirectUri = User::getChannelLink();
-    } else if (!empty($advancedCustomUser->afterLoginGoToURL)) {
+    } elseif (!empty($advancedCustomUser->afterLoginGoToURL)) {
         $object->redirectUri = $advancedCustomUser->afterLoginGoToURL;
     }
 }
@@ -220,7 +222,7 @@ if ((empty($object->redirectUri) || $object->redirectUri === $global['webSiteRoo
 if (empty($advancedCustomUser->userCanNotChangeCategory) || User::isAdmin()) {
     //_error_log("login.json.php get categories");
     $object->categories = Category::getAllCategories(true);
-    if(is_array($object->categories)){
+    if (is_array($object->categories)) {
         array_multisort(array_column($object->categories, 'hierarchyAndName'), SORT_ASC, $object->categories);
     }
 } else {
@@ -241,7 +243,7 @@ if ($object->isLogged) {
     if (!empty($p)) {
         require_once $global['systemRootPath'] . 'plugin/Live/Objects/LiveTransmition.php';
         $trasnmition = LiveTransmition::createTransmitionIfNeed(User::getId());
-        if(!empty($trasnmition)){
+        if (!empty($trasnmition)) {
             $object->streamServerURL = $p->getServer() . "?p=" . User::getUserPass();
             $object->streamKey = $trasnmition['key'];
         }

--- a/objects/notifySubscribers.json.php
+++ b/objects/notifySubscribers.json.php
@@ -1,6 +1,8 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
+
 global $global, $config;
-if(!isset($global['systemRootPath'])){
+if (!isset($global['systemRootPath'])) {
     require_once '../videos/configuration.php';
 }
 require_once $global['systemRootPath'] . 'objects/user.php';
@@ -11,14 +13,13 @@ if (!User::canUpload()) {
 }
 $user_id = User::getId();
 // if admin bring all subscribers
-if(User::isAdmin()){
+if (User::isAdmin()) {
     $user_id = "";
 }
 
 require_once 'subscribe.php';
 header('Content-Type: application/json');
 $Subscribes = Subscribe::getAllSubscribes($user_id);
-require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';
 
 $obj = new stdClass();
 //Create a new PHPMailer instance

--- a/objects/sendEmail.json.php
+++ b/objects/sendEmail.json.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
+
 global $global, $config;
 if (!isset($global['systemRootPath'])) {
     require_once '../videos/configuration.php';
@@ -9,10 +11,7 @@ $valid = Captcha::validation(@$_POST['captcha']);
 $obj = new stdClass();
 $obj->error = "";
 if ($valid) {
-
     $msg = "<b>Name:</b> {$_POST['first_name']}<br> <b>Email:</b> {$_POST['email']}<br><b>Website:</b> {$_POST['website']}<br><br>{$_POST['comment']}";
-    require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';
-
     //Create a new PHPMailer instance
     $mail = new \PHPMailer\PHPMailer\PHPMailer;
     setSiteSendMessage($mail);

--- a/objects/user.php
+++ b/objects/user.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
 
 if (empty($global['systemRootPath'])) {
     $global['systemRootPath'] = '../';
@@ -6,8 +7,8 @@ if (empty($global['systemRootPath'])) {
 require_once $global['systemRootPath'] . 'videos/configuration.php';
 require_once $global['systemRootPath'] . 'objects/bootGrid.php';
 
-class User {
-
+class User
+{
     private $id;
     private $user;
     private $name;
@@ -37,9 +38,10 @@ class User {
     private $city;
     private $donationLink;
     private $modified;
-    static $DOCUMENT_IMAGE_TYPE = "Document Image";
+    public static $DOCUMENT_IMAGE_TYPE = "Document Image";
 
-    function __construct($id, $user = "", $password = "") {
+    public function __construct($id, $user = "", $password = "")
+    {
         if (empty($id)) {
             // get the user data from user and pass
             $this->user = $user;
@@ -54,64 +56,79 @@ class User {
         }
     }
 
-    function getEmail() {
+    public function getEmail()
+    {
         return $this->email;
     }
 
-    function getUser() {
+    public function getUser()
+    {
         return $this->user;
     }
 
-    function getAbout() {
+    public function getAbout()
+    {
         return str_replace(array('\\\\\\\n'), array("\n"), $this->about);
     }
 
-    function setAbout($about) {
+    public function setAbout($about)
+    {
         $this->about = xss_esc($about);
     }
 
-    function getPassword() {
+    public function getPassword()
+    {
         return $this->password;
     }
 
-    function getCanStream() {
+    public function getCanStream()
+    {
         return $this->canStream;
     }
 
-    function setCanStream($canStream) {
+    public function setCanStream($canStream)
+    {
         $this->canStream = (empty($canStream) || strtolower($canStream) === 'false') ? 0 : 1;
     }
 
-    function getCanViewChart() {
+    public function getCanViewChart()
+    {
         return $this->canViewChart;
     }
 
-    function setCanViewChart($canViewChart) {
+    public function setCanViewChart($canViewChart)
+    {
         $this->canViewChart = (empty($canViewChart) || strtolower($canViewChart) === 'false') ? 0 : 1;
     }
 
-    function getCanCreateMeet() {
+    public function getCanCreateMeet()
+    {
         return $this->canCreateMeet;
     }
 
-    function setCanCreateMeet($canCreateMeet) {
+    public function setCanCreateMeet($canCreateMeet)
+    {
         $this->canCreateMeet = (empty($canCreateMeet) || strtolower($canCreateMeet) === 'false') ? 0 : 1;
         ;
     }
 
-    function getCanUpload() {
+    public function getCanUpload()
+    {
         return $this->canUpload;
     }
 
-    function setCanUpload($canUpload) {
+    public function setCanUpload($canUpload)
+    {
         $this->canUpload = (empty($canUpload) || strtolower($canUpload) === 'false') ? 0 : 1;
     }
 
-    function getAnalyticsCode() {
+    public function getAnalyticsCode()
+    {
         return $this->analyticsCode;
     }
 
-    function setAnalyticsCode($analyticsCode) {
+    public function setAnalyticsCode($analyticsCode)
+    {
         preg_match("/(ua-\d{4,9}-\d{1,4})/i", $analyticsCode, $matches);
         if (!empty($matches[1])) {
             $this->analyticsCode = $matches[1];
@@ -120,7 +137,8 @@ class User {
         }
     }
 
-    function getAnalytics() {
+    public function getAnalytics()
+    {
         $id = $this->getId();
         $aCode = $this->getAnalyticsCode();
         if (!empty($id) && !empty($aCode)) {
@@ -142,7 +160,8 @@ if (typeof gtag !== \"function\") {
         return $code;
     }
 
-    function addExternalOptions($id, $value) {
+    public function addExternalOptions($id, $value)
+    {
         $eo = unserialize(base64_decode($this->externalOptions));
         if (!is_array($eo)) {
             $eo = array();
@@ -152,41 +171,47 @@ if (typeof gtag !== \"function\") {
         return $this->save();
     }
 
-    function removeExternalOptions($id) {
+    public function removeExternalOptions($id)
+    {
         $eo = unserialize(base64_decode($this->externalOptions));
         unset($eo[$id]);
         $this->setExternalOptions($eo);
         return $this->save();
     }
 
-    function setExternalOptions($options) {
+    public function setExternalOptions($options)
+    {
         //we convert it to base64 to sanitize the input since we do not validate input from externalOptions
         $this->externalOptions = base64_encode(serialize($options));
     }
 
-    function getExternalOption($id) {
+    public function getExternalOption($id)
+    {
         $eo = unserialize(base64_decode($this->externalOptions));
         if (empty($eo[$id])) {
-            return NULL;
+            return null;
         }
         return $eo[$id];
     }
 
-    private function load($id) {
+    private function load($id)
+    {
         $id = intval($id);
         if (empty($id)) {
             return false;
         }
         $user = self::getUserDb($id);
-        if (empty($user))
+        if (empty($user)) {
             return false;
+        }
         foreach ($user as $key => $value) {
             $this->$key = $value;
         }
         return true;
     }
 
-    private function loadFromUser($user) {
+    private function loadFromUser($user)
+    {
         $userLoaded = self::getUserDbFromUser($user);
         if (empty($userLoaded)) {
             return false;
@@ -199,11 +224,13 @@ if (typeof gtag !== \"function\") {
         return true;
     }
 
-    function loadSelfUser() {
+    public function loadSelfUser()
+    {
         $this->load($this->getId());
     }
 
-    static function getId() {
+    public static function getId()
+    {
         if (self::isLogged()) {
             return $_SESSION['user']['id'];
         } else {
@@ -211,7 +238,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function getEmail_() {
+    public static function getEmail_()
+    {
         if (self::isLogged()) {
             return $_SESSION['user']['email'];
         } else {
@@ -219,18 +247,21 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    function getBdId() {
+    public function getBdId()
+    {
         return $this->id;
     }
 
-    static function updateSessionInfo() {
+    public static function updateSessionInfo()
+    {
         if (self::isLogged()) {
             $user = self::getUserDb($_SESSION['user']['id']);
             $_SESSION['user'] = $user;
         }
     }
 
-    static function getName() {
+    public static function getName()
+    {
         if (self::isLogged()) {
             return $_SESSION['user']['name'];
         } else {
@@ -238,7 +269,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function getUserName() {
+    public static function getUserName()
+    {
         if (self::isLogged()) {
             return $_SESSION['user']['user'];
         } else {
@@ -246,9 +278,9 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function getUserChannelName() {
+    public static function getUserChannelName()
+    {
         if (self::isLogged()) {
-
             if (empty($_SESSION['user']['channelName'])) {
                 $_SESSION['user']['channelName'] = self::_recommendChannelName();
                 $user = new User(User::getId());
@@ -262,7 +294,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function _recommendChannelName($name = "", $try = 0, $unknown = "", $users_id = 0) {
+    public static function _recommendChannelName($name = "", $try = 0, $unknown = "", $users_id = 0)
+    {
         if (empty($users_id)) {
             if (!empty(User::getId())) {
                 $users_id = User::getId();
@@ -300,7 +333,8 @@ if (typeof gtag !== \"function\") {
         return $name;
     }
 
-    static function getUserFromChannelName($channelName) {
+    public static function getUserFromChannelName($channelName)
+    {
         $channelName = cleanString($channelName);
         global $global;
         $channelName = $global['mysqli']->real_escape_string($channelName);
@@ -320,7 +354,8 @@ if (typeof gtag !== \"function\") {
      * return an name to identify the user
      * @return String
      */
-    static function getNameIdentification() {
+    public static function getNameIdentification()
+    {
         global $advancedCustomUser;
         if (self::isLogged()) {
             if (!empty(self::getName()) && empty($advancedCustomUser->doNotIndentifyByName)) {
@@ -343,7 +378,8 @@ if (typeof gtag !== \"function\") {
      * return an name to identify the user from database
      * @return String
      */
-    function getNameIdentificationBd() {
+    public function getNameIdentificationBd()
+    {
         global $advancedCustomUser;
         if (!empty($this->name) && empty($advancedCustomUser->doNotIndentifyByName)) {
             return $this->name;
@@ -360,7 +396,8 @@ if (typeof gtag !== \"function\") {
         return __("Unknown User");
     }
 
-    static function getNameIdentificationById($id = "") {
+    public static function getNameIdentificationById($id = "")
+    {
         if (!empty($id)) {
             $user = new User($id);
             return $user->getNameIdentificationBd();
@@ -368,7 +405,8 @@ if (typeof gtag !== \"function\") {
         return __("Unknown User");
     }
 
-    static function getUserPass() {
+    public static function getUserPass()
+    {
         if (self::isLogged()) {
             return $_SESSION['user']['password'];
         } else {
@@ -376,11 +414,13 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    function _getName() {
+    public function _getName()
+    {
         return $this->name;
     }
 
-    static function _getPhoto($id = "") {
+    public static function _getPhoto($id = "")
+    {
         global $global;
         if (!empty($id)) {
             $user = self::findById($id);
@@ -406,7 +446,8 @@ if (typeof gtag !== \"function\") {
         return $photo;
     }
 
-    static function getPhoto($id = "") {
+    public static function getPhoto($id = "")
+    {
         global $global;
         if (!empty($id)) {
             $user = self::findById($id);
@@ -429,17 +470,20 @@ if (typeof gtag !== \"function\") {
         return $photo;
     }
 
-    static function _getOGImage($users_id) {
+    public static function _getOGImage($users_id)
+    {
         return "/videos/userPhoto/photo{$users_id}_og_200X200.jpg";
     }
 
-    static function deleteOGImage($users_id) {
+    public static function deleteOGImage($users_id)
+    {
         global $global;
         $photo = $global['systemRootPath'] . self::_getOGImage($users_id);
         @unlink($photo);
     }
 
-    static function getOGImage($users_id = "") {
+    public static function getOGImage($users_id = "")
+    {
         global $global;
         $photo = self::_getPhoto($users_id);
         if ($photo == "view/img/userSilhouette.jpg") {
@@ -457,7 +501,8 @@ if (typeof gtag !== \"function\") {
         ;
     }
 
-    static function getEmailVerifiedIcon($id = "") {
+    public static function getEmailVerifiedIcon($id = "")
+    {
         global $advancedCustomUser;
         $mark = "";
         if (!empty($advancedCustomUser->showEmailVerifiedMark)) {
@@ -494,13 +539,15 @@ if (typeof gtag !== \"function\") {
         return $mark;
     }
 
-    function getPhotoDB() {
+    public function getPhotoDB()
+    {
         global $global;
         $photo = self::getPhoto($this->id);
         return $photo;
     }
 
-    static function getBackground($id = "") {
+    public static function getBackground($id = "")
+    {
         global $global;
         if (!empty($id)) {
             $user = self::findById($id);
@@ -523,7 +570,8 @@ if (typeof gtag !== \"function\") {
         return $photo;
     }
 
-    static function getMail() {
+    public static function getMail()
+    {
         if (self::isLogged()) {
             return $_SESSION['user']['email'];
         } else {
@@ -531,7 +579,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    function save($updateUserGroups = false) {
+    public function save($updateUserGroups = false)
+    {
         global $global, $config, $advancedCustom, $advancedCustomUser;
         if (is_object($config) && $config->currentVersionLowerThen('5.6')) {
             // they dont have analytics code
@@ -562,8 +611,9 @@ if (typeof gtag !== \"function\") {
         if (empty($this->status)) {
             $this->status = 'a';
         }
-        if (empty($this->emailVerified))
+        if (empty($this->emailVerified)) {
             $this->emailVerified = "false";
+        }
 
         $this->user = $global['mysqli']->real_escape_string($this->user);
         $this->password = $global['mysqli']->real_escape_string($this->password);
@@ -573,7 +623,7 @@ if (typeof gtag !== \"function\") {
         $this->about = preg_replace("/(\\\)+n/", "\n", $this->about);
         $this->channelName = self::_recommendChannelName($this->channelName, 0, $this->user, $this->id);
         $this->channelName = $global['mysqli']->real_escape_string($this->channelName);
-        if (filter_var($this->donationLink, FILTER_VALIDATE_URL) === FALSE) {
+        if (filter_var($this->donationLink, FILTER_VALIDATE_URL) === false) {
             $this->donationLink = "";
         }
         if (!empty($this->id)) {
@@ -643,7 +693,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function getChannelOwner($channelName) {
+    public static function getChannelOwner($channelName)
+    {
         global $global;
         $channelName = $global['mysqli']->real_escape_string($channelName);
         $sql = "SELECT * FROM users WHERE channelName = ? LIMIT 1";
@@ -658,7 +709,8 @@ if (typeof gtag !== \"function\") {
         return $user;
     }
 
-    static function getFromUsername($user) {
+    public static function getFromUsername($user)
+    {
         global $global;
         $user = $global['mysqli']->real_escape_string($user);
         $sql = "SELECT * FROM users WHERE user = ? LIMIT 1";
@@ -673,7 +725,8 @@ if (typeof gtag !== \"function\") {
         return $user;
     }
 
-    private static function setCacheWatchVideo($cacheName, $value) {
+    private static function setCacheWatchVideo($cacheName, $value)
+    {
         if (!User::isLogged()) {
             ObjectYPT::setCache($cacheName, $value);
             ;
@@ -682,7 +735,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function canWatchVideo($videos_id) {
+    public static function canWatchVideo($videos_id)
+    {
         $cacheName = "canWatchVideo$videos_id";
         if (!User::isLogged()) {
             $cache = ObjectYPT::getCache($cacheName, 3600);
@@ -763,7 +817,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function canWatchVideoWithAds($videos_id) {
+    public static function canWatchVideoWithAds($videos_id)
+    {
         if (empty($videos_id)) {
             _error_log("User::canWatchVideo (videos_id is empty) " . $videos_id);
             return false;
@@ -785,7 +840,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    function delete() {
+    public function delete()
+    {
         if (!self::isAdmin()) {
             return false;
         }
@@ -809,7 +865,8 @@ if (typeof gtag !== \"function\") {
     const CAPTCHA_ERROR = 3;
     const REQUIRE2FA = 4;
 
-    function login($noPass = false, $encodedPass = false) {
+    public function login($noPass = false, $encodedPass = false)
+    {
         if (User::isLogged()) {
             return false;
         }
@@ -837,7 +894,7 @@ if (typeof gtag !== \"function\") {
             unset($_SESSION['user']);
             self::sendVerificationLink($user['id']);
             return self::USER_NOT_VERIFIED;
-        } else if ($user) {
+        } elseif ($user) {
             $_SESSION['user'] = $user;
             $this->setLastLogin($_SESSION['user']['id']);
             $rememberme = 0;
@@ -861,7 +918,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function isCaptchaNeed() {
+    public static function isCaptchaNeed()
+    {
         global $advancedCustomUser;
         // check for multiple logins attempts to prevent hacking
         if (!empty($_SESSION['loginAttempts']) && !empty($advancedCustomUser->requestCaptchaAfterLoginsAttempts)) {
@@ -875,7 +933,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function checkLoginAttempts() {
+    public static function checkLoginAttempts()
+    {
         global $advancedCustomUser, $global;
         // check for multiple logins attempts to prevent hacking
         if (empty($_SESSION['loginAttempts'])) {
@@ -898,7 +957,8 @@ if (typeof gtag !== \"function\") {
         return true;
     }
 
-    static function getCaptchaFormIfNeed() {
+    public static function getCaptchaFormIfNeed()
+    {
         // check for multiple logins attempts to prevent hacking
         if (self::isCaptchaNeed()) {
             return self::getCaptchaForm();
@@ -906,7 +966,8 @@ if (typeof gtag !== \"function\") {
         return "";
     }
 
-    static function getCaptchaForm($uid = "") {
+    public static function getCaptchaForm($uid = "")
+    {
         global $global;
         return '<div class="input-group">'
                 . '<span class="input-group-addon"><img src="' . $global['webSiteRootURL'] . 'captcha" id="captcha' . $uid . '"></span>
@@ -923,7 +984,8 @@ if (typeof gtag !== \"function\") {
                 </script>';
     }
 
-    private function setLastLogin($user_id) {
+    private function setLastLogin($user_id)
+    {
         global $global;
         if (empty($user_id)) {
             die('Error : setLastLogin ');
@@ -932,7 +994,8 @@ if (typeof gtag !== \"function\") {
         return sqlDAL::writeSql($sql, "i", array($user_id));
     }
 
-    static function logoff() {
+    public static function logoff()
+    {
         global $global, $justLogoff;
         $justLogoff = true;
         _session_start();
@@ -943,12 +1006,12 @@ if (typeof gtag !== \"function\") {
         unset($_SESSION['user']);
     }
 
-    static private function recreateLoginFromCookie() {
+    private static function recreateLoginFromCookie()
+    {
         global $justLogoff, $justTryToRecreateLoginFromCookie;
         if (empty($justTryToRecreateLoginFromCookie) && empty($justLogoff) && empty($_SESSION['user']['id'])) {
             $justTryToRecreateLoginFromCookie = 1;
             if ((!empty($_COOKIE['user'])) && (!empty($_COOKIE['pass'])) && (!empty($_COOKIE['rememberme']))) {
-
                 $user = new User(0, $_COOKIE['user'], false);
                 $user->setPassword($_COOKIE['pass'], true);
                 //  $dbuser = self::getUserDbFromUser($_COOKIE['user']);
@@ -965,35 +1028,40 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function isLogged() {
+    public static function isLogged()
+    {
         self::recreateLoginFromCookie();
         return !empty($_SESSION['user']['id']);
     }
 
-    static function isVerified() {
+    public static function isVerified()
+    {
         self::recreateLoginFromCookie();
         return !empty($_SESSION['user']['emailVerified']);
     }
 
-    static function isAdmin() {
+    public static function isAdmin()
+    {
         self::recreateLoginFromCookie();
         return !empty($_SESSION['user']['isAdmin']);
     }
 
-    static function canStream() {
+    public static function canStream()
+    {
         self::recreateLoginFromCookie();
         return !empty($_SESSION['user']['isAdmin']) || !empty($_SESSION['user']['canStream']);
     }
 
-    static function externalOptions($id) {
+    public static function externalOptions($id)
+    {
         if (!empty($_SESSION['user']['externalOptions'])) {
             $externalOptions = unserialize(base64_decode($_SESSION['user']['externalOptions']));
             if (isset($externalOptions[$id])) {
-                if ($externalOptions[$id] == "true")
+                if ($externalOptions[$id] == "true") {
                     $externalOptions[$id] = true;
-                else
-                if ($externalOptions[$id] == "false")
+                } elseif ($externalOptions[$id] == "false") {
                     $externalOptions[$id] = false;
+                }
 
                 return $externalOptions[$id];
             }
@@ -1001,7 +1069,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function externalOptionsFromUserID($users_id, $id) {
+    public static function externalOptionsFromUserID($users_id, $id)
+    {
         $user = self::findById($users_id);
         if ($user) {
             if (!is_null($user['externalOptions'])) {
@@ -1011,11 +1080,11 @@ if (typeof gtag !== \"function\") {
                         if ($id != $k) {
                             continue;
                         }
-                        if ($v == "true")
+                        if ($v == "true") {
                             $v = 1;
-                        else
-                        if ($v == "false")
+                        } elseif ($v == "false") {
                             $v = 0;
+                        }
                         return $v;
                     }
                 }
@@ -1024,14 +1093,16 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    function thisUserCanStream() {
+    public function thisUserCanStream()
+    {
         if ($this->status === 'i') {
             return false;
         }
         return !empty($this->isAdmin) || !empty($this->canStream);
     }
 
-    private function find($user, $pass, $mustBeactive = false, $encodedPass = false) {
+    private function find($user, $pass, $mustBeactive = false, $encodedPass = false)
+    {
         global $global, $advancedCustom;
         $formats = "";
         $values = array();
@@ -1079,7 +1150,8 @@ if (typeof gtag !== \"function\") {
      * @param type $encodedPass
      * @return boolean
      */
-    private function find_Old($user, $pass, $mustBeactive = false, $encodedPass = false) {
+    private function find_Old($user, $pass, $mustBeactive = false, $encodedPass = false)
+    {
         global $global;
         $formats = "";
         $values = array();
@@ -1128,7 +1200,8 @@ if (typeof gtag !== \"function\") {
         return $user;
     }
 
-    static private function findById($id) {
+    private static function findById($id)
+    {
         global $global;
         $id = intval($id);
         if (empty($id)) {
@@ -1146,7 +1219,8 @@ if (typeof gtag !== \"function\") {
         return $user;
     }
 
-    static function findByEmail($email) {
+    public static function findByEmail($email)
+    {
         global $global;
         $email = trim($email);
         if (empty($email)) {
@@ -1164,7 +1238,8 @@ if (typeof gtag !== \"function\") {
         return $user;
     }
 
-    static private function getUserDb($id) {
+    private static function getUserDb($id)
+    {
         global $global;
         $id = intval($id);
         if (empty($id)) {
@@ -1180,7 +1255,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static private function getUserDbFromUser($user) {
+    private static function getUserDbFromUser($user)
+    {
         global $global;
         if (empty($user)) {
             return false;
@@ -1195,7 +1271,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function getUserFromID($users_id) {
+    public static function getUserFromID($users_id)
+    {
         global $global;
         if (empty($users_id)) {
             return false;
@@ -1216,11 +1293,11 @@ if (typeof gtag !== \"function\") {
                 $externalOptions = unserialize(base64_decode($user['externalOptions']));
                 if (is_array($externalOptions) && sizeof($externalOptions) > 0) {
                     foreach ($externalOptions as $k => $v) {
-                        if ($v == "true")
+                        if ($v == "true") {
                             $v = 1;
-                        else
-                        if ($v == "false")
+                        } elseif ($v == "false") {
                             $v = 0;
+                        }
                         $user[$k] = $v;
                     }
                 }
@@ -1242,7 +1319,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function getUserFromEmail($email) {
+    public static function getUserFromEmail($email)
+    {
         $sql = "SELECT * FROM users WHERE email = ? LIMIT 1";
         $res = sqlDAL::readSql($sql, "s", array($email));
         $user = sqlDAL::fetchAssoc($res);
@@ -1253,7 +1331,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    function setUser($user) {
+    public function setUser($user)
+    {
         global $advancedCustomUser;
         if (empty($advancedCustomUser->userCanChangeUsername)) {
             if (!empty($this->user)) {
@@ -1263,11 +1342,13 @@ if (typeof gtag !== \"function\") {
         $this->user = strip_tags($user);
     }
 
-    function setName($name) {
+    public function setName($name)
+    {
         $this->name = strip_tags($name);
     }
 
-    function setEmail($email) {
+    public function setEmail($email)
+    {
         global $advancedCustomUser;
         $email = strip_tags($email);
         if (!empty($advancedCustomUser->emailMustBeUnique)) {
@@ -1283,7 +1364,8 @@ if (typeof gtag !== \"function\") {
         return true;
     }
 
-    function setPassword($password, $doNotEncrypt = false) {
+    public function setPassword($password, $doNotEncrypt = false)
+    {
         if (!empty($password)) {
             if ($doNotEncrypt) {
                 $this->password = ($password);
@@ -1293,7 +1375,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    function setIsAdmin($isAdmin) {
+    public function setIsAdmin($isAdmin)
+    {
         if (empty($isAdmin) || $isAdmin === "false" || !User::isAdmin()) {
             $isAdmin = "0";
         } else {
@@ -1302,24 +1385,28 @@ if (typeof gtag !== \"function\") {
         $this->isAdmin = $isAdmin;
     }
 
-    function setStatus($status) {
+    public function setStatus($status)
+    {
         $this->status = strip_tags($status);
     }
 
-    function getPhotoURL() {
+    public function getPhotoURL()
+    {
         return $this->photoURL;
     }
 
-    function setPhotoURL($photoURL) {
+    public function setPhotoURL($photoURL)
+    {
         $this->photoURL = strip_tags($photoURL);
     }
 
-    static function getAllUsersFromUsergroup($users_groups_id, $ignoreAdmin = false, $searchFields = array('name', 'email', 'user', 'channelName', 'about'), $status = "") {
+    public static function getAllUsersFromUsergroup($users_groups_id, $ignoreAdmin = false, $searchFields = array('name', 'email', 'user', 'channelName', 'about'), $status = "")
+    {
         if (!Permissions::canAdminUsers() && !$ignoreAdmin) {
             return false;
         }
         $users_groups_id = intval($users_groups_id);
-        if(empty($users_groups_id)){
+        if (empty($users_groups_id)) {
             return false;
         }
         //will receive
@@ -1354,12 +1441,13 @@ if (typeof gtag !== \"function\") {
     }
 
 
-    static function getTotalUsersFromUsergroup($users_groups_id, $ignoreAdmin = false, $status = "") {
+    public static function getTotalUsersFromUsergroup($users_groups_id, $ignoreAdmin = false, $status = "")
+    {
         if (!Permissions::canAdminUsers() && !$ignoreAdmin) {
             return false;
         }
         $users_groups_id = intval($users_groups_id);
-        if(empty($users_groups_id)){
+        if (empty($users_groups_id)) {
             return false;
         }
         //will receive
@@ -1385,7 +1473,8 @@ if (typeof gtag !== \"function\") {
         return $result;
     }
 
-    static function getAllUsers($ignoreAdmin = false, $searchFields = array('name', 'email', 'user', 'channelName', 'about'), $status = "") {
+    public static function getAllUsers($ignoreAdmin = false, $searchFields = array('name', 'email', 'user', 'channelName', 'about'), $status = "")
+    {
         if (!Permissions::canAdminUsers() && !$ignoreAdmin) {
             return false;
         }
@@ -1419,7 +1508,8 @@ if (typeof gtag !== \"function\") {
         return $user;
     }
 
-    static private function getUserInfoFromRow($row) {
+    private static function getUserInfoFromRow($row)
+    {
         $row['groups'] = UserGroups::getUserGroups($row['id']);
         $row['identification'] = self::getNameIdentificationById($row['id']);
         $row['photo'] = self::getPhoto($row['id']);
@@ -1431,11 +1521,11 @@ if (typeof gtag !== \"function\") {
             $externalOptions = unserialize(base64_decode($row['externalOptions']));
             if (is_array($externalOptions) && sizeof($externalOptions) > 0) {
                 foreach ($externalOptions as $k => $v) {
-                    if ($v == "true")
+                    if ($v == "true") {
                         $v = 1;
-                    else
-                    if ($v == "false")
+                    } elseif ($v == "false") {
                         $v = 0;
+                    }
                     $row[$k] = $v;
                 }
             }
@@ -1454,7 +1544,8 @@ if (typeof gtag !== \"function\") {
         return $row;
     }
 
-    static function getAllUsersThatHasVideos($ignoreAdmin = false) {
+    public static function getAllUsersThatHasVideos($ignoreAdmin = false)
+    {
         if (!self::isAdmin() && !$ignoreAdmin) {
             return false;
         }
@@ -1478,7 +1569,8 @@ if (typeof gtag !== \"function\") {
         return $user;
     }
 
-    static function getTotalUsers($ignoreAdmin = false, $status = "") {
+    public static function getTotalUsers($ignoreAdmin = false, $status = "")
+    {
         if (!Permissions::canAdminUsers() && !$ignoreAdmin) {
             return false;
         }
@@ -1504,7 +1596,8 @@ if (typeof gtag !== \"function\") {
         return $result;
     }
 
-    static function userExists($user) {
+    public static function userExists($user)
+    {
         global $global;
         $user = $global['mysqli']->real_escape_string($user);
         $sql = "SELECT * FROM users WHERE user = ? LIMIT 1";
@@ -1519,7 +1612,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function idExists($users_id) {
+    public static function idExists($users_id)
+    {
         global $global;
         $users_id = intval($users_id);
         $sql = "SELECT * FROM users WHERE id = ? LIMIT 1";
@@ -1533,7 +1627,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function createUserIfNotExists($user, $pass, $name, $email, $photoURL, $isAdmin = false, $emailVerified = false) {
+    public static function createUserIfNotExists($user, $pass, $name, $email, $photoURL, $isAdmin = false, $emailVerified = false)
+    {
         global $global, $advancedCustomUser;
         $user = $global['mysqli']->real_escape_string($user);
         $userId = 0;
@@ -1567,11 +1662,13 @@ if (typeof gtag !== \"function\") {
         return $userId;
     }
 
-    function getRecoverPass() {
+    public function getRecoverPass()
+    {
         return $this->recoverPass;
     }
 
-    function setRecoverPass($recoverPass, $forceChange = false) {
+    public function setRecoverPass($recoverPass, $forceChange = false)
+    {
         // let the same recover pass if it was 10 minutes ago
         if (empty($forceChange) && !empty($this->recoverPass) && !empty($recoverPass) && !empty($this->modified) && strtotime($this->modified) > strtotime("-10 minutes")) {
             return $this->recoverPass;
@@ -1580,7 +1677,8 @@ if (typeof gtag !== \"function\") {
         return $this->recoverPass;
     }
 
-    static function canUpload($doNotCheckPlugins = false) {
+    public static function canUpload($doNotCheckPlugins = false)
+    {
         global $global, $config, $advancedCustomUser;
         if (Permissions::canModerateVideos()) {
             return true;
@@ -1605,7 +1703,8 @@ if (typeof gtag !== \"function\") {
         return self::isAdmin();
     }
 
-    static function canViewChart() {
+    public static function canViewChart()
+    {
         global $global, $config;
         if (self::isLogged() && !empty($_SESSION['user']['canViewChart'])) {
             return true;
@@ -1613,7 +1712,8 @@ if (typeof gtag !== \"function\") {
         return self::isAdmin();
     }
 
-    static function canCreateMeet() {
+    public static function canCreateMeet()
+    {
         global $global, $config;
         if (self::isLogged() && !empty($_SESSION['user']['canCreateMeet'])) {
             return true;
@@ -1621,7 +1721,8 @@ if (typeof gtag !== \"function\") {
         return self::isAdmin();
     }
 
-    static function canComment() {
+    public static function canComment()
+    {
         global $global, $config, $advancedCustomUser;
         if (self::isAdmin()) {
             return true;
@@ -1641,7 +1742,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function canSeeCommentTextarea() {
+    public static function canSeeCommentTextarea()
+    {
         global $global, $config;
         if (!$config->getAuthCanComment()) {
             if (!self::isAdmin()) {
@@ -1651,21 +1753,25 @@ if (typeof gtag !== \"function\") {
         return true;
     }
 
-    function getUserGroups() {
+    public function getUserGroups()
+    {
         return $this->userGroups;
     }
 
-    function setUserGroups($userGroups) {
+    public function setUserGroups($userGroups)
+    {
         if (is_array($userGroups)) {
             $this->userGroups = $userGroups;
         }
     }
 
-    function getIsAdmin() {
+    public function getIsAdmin()
+    {
         return $this->isAdmin;
     }
 
-    function getStatus() {
+    public function getStatus()
+    {
         return $this->status;
     }
 
@@ -1675,7 +1781,8 @@ if (typeof gtag !== \"function\") {
      * text
      * label Default Primary Success Info Warning Danger
      */
-    static function getTags($user_id) {
+    public static function getTags($user_id)
+    {
         $user = new User($user_id);
         $tags = array();
         if ($user->getIsAdmin()) {
@@ -1729,13 +1836,15 @@ if (typeof gtag !== \"function\") {
         return $tags;
     }
 
-    function getBackgroundURL() {
+    public function getBackgroundURL()
+    {
         global $global;
         $this->backgroundURL = self::getBackgroundURLFromUserID($this->id);
         return $this->backgroundURL;
     }
 
-    static function getBackgroundURLFromUserID($users_id = 0) {
+    public static function getBackgroundURLFromUserID($users_id = 0)
+    {
         if (empty($users_id)) {
             $users_id = User::getId();
         }
@@ -1750,11 +1859,13 @@ if (typeof gtag !== \"function\") {
         return $backgroundURL;
     }
 
-    function setBackgroundURL($backgroundURL) {
+    public function setBackgroundURL($backgroundURL)
+    {
         $this->backgroundURL = strip_tags($backgroundURL);
     }
 
-    function getChannelName() {
+    public function getChannelName()
+    {
         if (empty($this->channelName)) {
             $this->channelName = self::_recommendChannelName($this->channelName);
             $this->save();
@@ -1762,7 +1873,8 @@ if (typeof gtag !== \"function\") {
         return $this->channelName;
     }
 
-    static function _getUserChannelName($users_id = 0) {
+    public static function _getUserChannelName($users_id = 0)
+    {
         global $global, $config;
         if (empty($users_id)) {
             $users_id = self::getId();
@@ -1775,11 +1887,13 @@ if (typeof gtag !== \"function\") {
         return $user->getChannelName();
     }
 
-    function getEmailVerified() {
+    public function getEmailVerified()
+    {
         return intval($this->emailVerified);
     }
 
-    static function validateChannelName($channelName) {
+    public static function validateChannelName($channelName)
+    {
         return trim(preg_replace("/[^0-9A-Z_]/i", "", ucwords($channelName)));
     }
 
@@ -1788,7 +1902,8 @@ if (typeof gtag !== \"function\") {
      * @param type $channelName
      * @return boolean return true is is unique
      */
-    function setChannelName($channelName) {
+    public function setChannelName($channelName)
+    {
         $channelName = self::validateChannelName($channelName);
         $user = static::getChannelOwner($channelName);
         if (!empty($user)) { // if the channel name exists and it is not from this user, rename the channel name
@@ -1800,11 +1915,13 @@ if (typeof gtag !== \"function\") {
         return true;
     }
 
-    function setEmailVerified($emailVerified) {
+    public function setEmailVerified($emailVerified)
+    {
         $this->emailVerified = (empty($emailVerified) || strtolower($emailVerified) === 'false') ? 0 : 1;
     }
 
-    static function getChannelLink($users_id = 0) {
+    public static function getChannelLink($users_id = 0)
+    {
         global $global;
         $name = self::_getChannelName($users_id);
         if (empty($name)) {
@@ -1814,13 +1931,15 @@ if (typeof gtag !== \"function\") {
         return $link;
     }
 
-    static function getChannelLinkFromChannelName($channelName) {
+    public static function getChannelLinkFromChannelName($channelName)
+    {
         global $global;
         $link = "{$global['webSiteRootURL']}channel/" . urlencode($channelName);
         return $link;
     }
 
-    static function _getChannelName($users_id = 0) {
+    public static function _getChannelName($users_id = 0)
+    {
         global $global, $config;
         if (empty($users_id)) {
             $users_id = self::getId();
@@ -1837,7 +1956,8 @@ if (typeof gtag !== \"function\") {
         return $name;
     }
 
-    static function sendVerificationLink($users_id) {
+    public static function sendVerificationLink($users_id)
+    {
         global $global, $advancedCustomUser;
         //Only send the verification email each 30 minutes
         if (!empty($_SESSION["sendVerificationLink"][$users_id]) && time() - $_SESSION["sendVerificationLink"][$users_id] > 1800) {
@@ -1847,7 +1967,6 @@ if (typeof gtag !== \"function\") {
         $config = new Configuration();
         $user = new User($users_id);
         $code = urlencode(static::createVerificationCode($users_id));
-        require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';
         //Create a new PHPMailer instance
         if (!is_object($config)) {
             _error_log("sendVerificationLink: config is not a object " . json_encode($config));
@@ -1891,7 +2010,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function verifyCode($code) {
+    public static function verifyCode($code)
+    {
         global $global;
         $obj = static::decodeVerificationCode($code);
         $salt = hash('sha256', $global['salt']);
@@ -1907,7 +2027,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function createVerificationCode($users_id) {
+    public static function createVerificationCode($users_id)
+    {
         global $global;
         $obj = new stdClass();
         $obj->users_id = $users_id;
@@ -1921,68 +2042,84 @@ if (typeof gtag !== \"function\") {
         return base64_encode(json_encode($obj));
     }
 
-    static function decodeVerificationCode($code) {
+    public static function decodeVerificationCode($code)
+    {
         $obj = json_decode(base64_decode($code));
         return $obj;
     }
 
-    function getFirst_name() {
+    public function getFirst_name()
+    {
         return $this->first_name;
     }
 
-    function getLast_name() {
+    public function getLast_name()
+    {
         return $this->last_name;
     }
 
-    function getAddress() {
+    public function getAddress()
+    {
         return $this->address;
     }
 
-    function getZip_code() {
+    public function getZip_code()
+    {
         return $this->zip_code;
     }
 
-    function getCountry() {
+    public function getCountry()
+    {
         return $this->country;
     }
 
-    function getRegion() {
+    public function getRegion()
+    {
         return $this->region;
     }
 
-    function getCity() {
+    public function getCity()
+    {
         return $this->city;
     }
 
-    function setFirst_name($first_name) {
+    public function setFirst_name($first_name)
+    {
         $this->first_name = $first_name;
     }
 
-    function setLast_name($last_name) {
+    public function setLast_name($last_name)
+    {
         $this->last_name = $last_name;
     }
 
-    function setAddress($address) {
+    public function setAddress($address)
+    {
         $this->address = $address;
     }
 
-    function setZip_code($zip_code) {
+    public function setZip_code($zip_code)
+    {
         $this->zip_code = $zip_code;
     }
 
-    function setCountry($country) {
+    public function setCountry($country)
+    {
         $this->country = $country;
     }
 
-    function setRegion($region) {
+    public function setRegion($region)
+    {
         $this->region = $region;
     }
 
-    function setCity($city) {
+    public function setCity($city)
+    {
         $this->city = $city;
     }
 
-    static function getDocumentImage($users_id) {
+    public static function getDocumentImage($users_id)
+    {
         $row = static::getBlob($users_id, User::$DOCUMENT_IMAGE_TYPE);
         if (!empty($row['blob'])) {
             return $row['blob'];
@@ -1990,7 +2127,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function saveDocumentImage($image, $users_id) {
+    public static function saveDocumentImage($image, $users_id)
+    {
         $row = static::saveBlob($image, $users_id, User::$DOCUMENT_IMAGE_TYPE);
         if (!empty($row['blob'])) {
             return $row['blob'];
@@ -1998,7 +2136,8 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    static function getBlob($users_id, $type) {
+    public static function getBlob($users_id, $type)
+    {
         global $global;
         $sql = "SELECT * FROM users_blob WHERE users_id = ? AND `type` = ? LIMIT 1";
         $res = sqlDAL::readSql($sql, "is", array($users_id, $type));
@@ -2007,10 +2146,11 @@ if (typeof gtag !== \"function\") {
         return $result;
     }
 
-    static function saveBlob($blob, $users_id, $type) {
+    public static function saveBlob($blob, $users_id, $type)
+    {
         global $global;
         $row = self::getBlob($users_id, $type);
-        $null = NULL;
+        $null = null;
         if (!empty($row['id'])) {
             $sql = "UPDATE users_blob SET `blob` = ? , modified = now() WHERE id = ?";
             $stmt = $global['mysqli']->prepare($sql);
@@ -2027,7 +2167,8 @@ if (typeof gtag !== \"function\") {
         return $stmt->execute();
     }
 
-    static function deleteBlob($users_id, $type) {
+    public static function deleteBlob($users_id, $type)
+    {
         global $global;
         $row = self::getBlob($users_id, $type);
         if (!empty($row['id'])) {
@@ -2041,11 +2182,13 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    function getDonationLink() {
+    public function getDonationLink()
+    {
         return $this->donationLink;
     }
 
-    function getDonationLinkIfEnabled() {
+    public function getDonationLinkIfEnabled()
+    {
         global $advancedCustomUser;
         if ($advancedCustomUser->allowDonationLink) {
             return $this->donationLink;
@@ -2053,11 +2196,13 @@ if (typeof gtag !== \"function\") {
         return false;
     }
 
-    function setDonationLink($donationLink) {
+    public function setDonationLink($donationLink)
+    {
         $this->donationLink = $donationLink;
     }
 
-    static function donationLink() {
+    public static function donationLink()
+    {
         if (self::isLogged()) {
             return $_SESSION['user']['donationLink'];
         } else {
@@ -2065,9 +2210,10 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function loginFromRequest() {
+    public static function loginFromRequest()
+    {
         $inputJSON = url_get_contents('php://input');
-        $input = json_decode($inputJSON, TRUE); //convert JSON into array
+        $input = json_decode($inputJSON, true); //convert JSON into array
         if (is_array($input)) {
             foreach ($input as $key => $value) {
                 if (empty($_REQUEST[$key])) {
@@ -2084,7 +2230,8 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    static function loginFromRequestToGet() {
+    public static function loginFromRequestToGet()
+    {
         if (!empty($_REQUEST['user']) && !empty($_REQUEST['pass'])) {
             $return = "user={$_REQUEST['user']}&pass={$_REQUEST['pass']}";
             if (!empty($_REQUEST['encodedPass'])) {
@@ -2095,7 +2242,8 @@ if (typeof gtag !== \"function\") {
         return "";
     }
 
-    static function getBlockUserButton($users_id) {
+    public static function getBlockUserButton($users_id)
+    {
         $canBlock = self::userCanBlockUserWithReason($users_id);
         if (!$canBlock->result) {
             return "<!-- {$canBlock->msg} -->";
@@ -2103,7 +2251,8 @@ if (typeof gtag !== \"function\") {
         return ReportVideo::buttonBlockUser($users_id);
     }
 
-    static function getActionBlockUserButton($users_id) {
+    public static function getActionBlockUserButton($users_id)
+    {
         $canBlock = self::userCanBlockUserWithReason($users_id);
         if (!$canBlock->result) {
             return "<!-- {$canBlock->msg} -->";
@@ -2111,7 +2260,8 @@ if (typeof gtag !== \"function\") {
         return ReportVideo::actionButtonBlockUser($users_id);
     }
 
-    static function userCanBlockUser($users_id, $ignoreIfIsAlreadyBLocked = false) {
+    public static function userCanBlockUser($users_id, $ignoreIfIsAlreadyBLocked = false)
+    {
         if (empty($users_id)) {
             return false;
         }
@@ -2130,7 +2280,8 @@ if (typeof gtag !== \"function\") {
         return true;
     }
 
-    static function userCanBlockUserWithReason($users_id, $ignoreIfIsAlreadyBLocked = false) {
+    public static function userCanBlockUserWithReason($users_id, $ignoreIfIsAlreadyBLocked = false)
+    {
         $obj = new stdClass();
         $obj->result = false;
         $obj->msg = "Unkonw";
@@ -2160,7 +2311,8 @@ if (typeof gtag !== \"function\") {
         return $obj;
     }
 
-    static function hasBlockedUser($reported_users_id, $users_id = 0) {
+    public static function hasBlockedUser($reported_users_id, $users_id = 0)
+    {
         if (empty($users_id)) {
             $users_id = User::getId();
         }
@@ -2175,14 +2327,13 @@ if (typeof gtag !== \"function\") {
         }
     }
 
-    function updateUserImages($params = array()) {
-
+    public function updateUserImages($params = array())
+    {
         $id = $this->id;
         $obj = new stdClass();
 
         // Update Background Image
         if (isset($params['backgroundImg']) && $params['backgroundImg'] != '') {
-
             $background = url_get_contents($params['backgroundImg']);
             $ext = pathinfo(parse_url($params['backgroundImg'], PHP_URL_PATH), PATHINFO_EXTENSION);
             $allowed = array('jpg', 'jpeg', 'gif', 'png');
@@ -2221,7 +2372,6 @@ if (typeof gtag !== \"function\") {
 
         // Update Profile Image
         if (isset($params['profileImg']) && $params['profileImg'] != '') {
-
             $photo = url_get_contents($params['profileImg']);
             $photoPath = "videos/userPhoto/photo{$id}.png";
 
@@ -2259,5 +2409,4 @@ if (typeof gtag !== \"function\") {
 
         return $obj;
     }
-
 }

--- a/objects/userRecoverPass.php
+++ b/objects/userRecoverPass.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
+
 global $global, $config;
 if (!isset($global['systemRootPath'])) {
     require_once '../videos/configuration.php';
@@ -18,8 +20,6 @@ if (!(!empty($_GET['user']) && !empty($_GET['recoverpass']))) {
             require_once 'captcha.php';
             $valid = Captcha::validation($_POST['captcha']);
             if ($valid) {
-                require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';
-
                 //Create a new PHPMailer instance
                 $mail = new \PHPMailer\PHPMailer\PHPMailer;
                 setSiteSendMessage($mail);
@@ -57,14 +57,12 @@ if (!(!empty($_GET['user']) && !empty($_GET['recoverpass']))) {
         <head>
             <title><?php echo __("Recover Password") . $config->getPageTitleSeparator() . $config->getWebSiteTitle(); ?></title>
             <?php
-            include $global['systemRootPath'] . 'view/include/head.php';
-            ?>
+            include $global['systemRootPath'] . 'view/include/head.php'; ?>
         </head>
 
         <body class="<?php echo $global['bodyClass']; ?>">
             <?php
-            include $global['systemRootPath'] . 'view/include/navbar.php';
-            ?>
+            include $global['systemRootPath'] . 'view/include/navbar.php'; ?>
 
             <div class="container">
                 <?php
@@ -103,8 +101,7 @@ if (!(!empty($_GET['user']) && !empty($_GET['recoverpass']))) {
                                 <label class="col-md-4 control-label"><?php echo __("New Password"); ?></label>
                                 <div class="col-md-8 inputGroupContainer">
                                     <?php
-                                    getInputPassword("newPassword", 'class="form-control" required="required" autocomplete="off"', __("New Password"));
-                                    ?>
+                                    getInputPassword("newPassword", 'class="form-control" required="required" autocomplete="off"', __("New Password")); ?>
                                 </div>
                             </div>
 
@@ -112,8 +109,7 @@ if (!(!empty($_GET['user']) && !empty($_GET['recoverpass']))) {
                                 <label class="col-md-4 control-label"><?php echo __("Confirm New Password"); ?></label>
                                 <div class="col-md-8 inputGroupContainer">
                                     <?php
-                                    getInputPassword("newPasswordConfirm", 'class="form-control" required="required" autocomplete="off"', __("Confirm New Password"));
-                                    ?>
+                                    getInputPassword("newPasswordConfirm", 'class="form-control" required="required" autocomplete="off"', __("Confirm New Password")); ?>
                                 </div>
                             </div>
 
@@ -129,15 +125,13 @@ if (!(!empty($_GET['user']) && !empty($_GET['recoverpass']))) {
                         </fieldset>
                     </form>
                     <?php
-                }
-                ?>
+                } ?>
             </div>
 
         </div><!--/.container-->
 
         <?php
-        include $global['systemRootPath'] . 'view/include/footer.php';
-        ?>
+        include $global['systemRootPath'] . 'view/include/footer.php'; ?>
 
         <script>
             $(document).ready(function () {

--- a/objects/video.php
+++ b/objects/video.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
+
 global $global, $config, $videosPaths;
 
 if (!isset($global['systemRootPath'])) {
@@ -103,9 +105,8 @@ if (!class_exists('Video')) {
                 $this->views_count++;
                 AVideoPlugin::addView($this->id, $this->views_count);
                 return $obj;
-            } else {
-                die($sql . ' Error : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
             }
+            die($sql . ' Error : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
         }
 
         public function updateViewsCount($total)
@@ -124,9 +125,8 @@ if (!class_exists('Video')) {
 
             if ($insert_row) {
                 return $insert_row;
-            } else {
-                die($sql . ' Error : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
             }
+            die($sql . ' Error : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
         }
 
         public function addViewPercent($percent = 25)
@@ -141,9 +141,8 @@ if (!class_exists('Video')) {
 
             if ($insert_row) {
                 return true;
-            } else {
-                die($sql . ' Error : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
             }
+            die($sql . ' Error : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
         }
 
         // allow users to count a view again in case it is refreshed
@@ -373,10 +372,9 @@ if (!class_exists('Video')) {
                 }
                 self::clearCache($this->id);
                 return $id;
-            } else {
-                _error_log('Video::save ' . $sql . ' Save Video Error : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error . " $sql");
-                return false;
             }
+            _error_log('Video::save ' . $sql . ' Save Video Error : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error . " $sql");
+            return false;
         }
 
         /*
@@ -547,9 +545,9 @@ if (!class_exists('Video')) {
                         sqlDAL::close($res);
                         if ($res != false) {
                             foreach ($fullResult as $row) {
-                                if ($row['type'] == "audio") {
+                                if ($row['type'] == 'audio') {
                                     $audioFound = true;
-                                } elseif ($row['type'] == "video") {
+                                } elseif ($row['type'] == 'video') {
                                     $videoFound = true;
                                 }
                             }
@@ -1851,7 +1849,6 @@ if (!class_exists('Video')) {
             global $global, $advancedCustom;
             if (empty($advancedCustom->disableHTMLDescription)) {
                 $articleObj = AVideoPlugin::getObjectData('Articles');
-                require_once $global['systemRootPath'] . 'objects/ezyang/htmlpurifier/library/HTMLPurifier.auto.php';
                 $configPuri = HTMLPurifier_Config::createDefault();
                 $purifier = new HTMLPurifier($configPuri);
                 if (empty($articleObj->allowAttributes)) {
@@ -1944,7 +1941,6 @@ if (!class_exists('Video')) {
         public static function getDurationFromFile($file)
         {
             global $global;
-            require_once $global['systemRootPath'] . 'objects/james-heinrich/getid3/getid3/getid3.php';
             // get movie duration HOURS:MM:SS.MICROSECONDS
             if (!file_exists($file)) {
                 _error_log('{"status":"error", "msg":"getDurationFromFile ERROR, File (' . $file . ') Not Found"}');
@@ -1984,7 +1980,6 @@ if (!class_exists('Video')) {
             if (preg_match("/.m3u8$/i", $file) && AVideoPlugin::isEnabledByName('VideoHLS') && method_exists(new VideoHLS(), 'getHLSHigestResolutionFromFile')) {
                 $videogetResolution[$file] = VideoHLS::getHLSHigestResolutionFromFile($file);
             } else {
-                require_once $global['systemRootPath'] . 'objects/james-heinrich/getid3/getid3/getid3.php';
                 $getID3 = new getID3;
                 $ThisFileInfo = $getID3->analyze($file);
                 $videogetResolution[$file] = intval(@$ThisFileInfo['video']['resolution_y']);
@@ -3999,16 +3994,12 @@ if (!class_exists('Video')) {
         public static function getIncludeType($video)
         {
             $vType = $video['type'];
-            if ($vType == "linkVideo") {
-                if (isHTMLPage($video['videoLink'])) {
-                    $vType = "embed";
-                } else {
-                    $vType = "video";
-                }
-            } elseif ($vType == "live") {
-                $vType = "../../plugin/Live/view/liveVideo";
-            } elseif ($vType == "linkAudio") {
-                $vType = "audio";
+            if ($vType == 'linkVideo') {
+                $vType = isHTMLPage($video['videoLink']) ? 'embed' : 'video';
+            } elseif ($vType == 'live') {
+                $vType = '../../plugin/Live/view/liveVideo';
+            } elseif ($vType == 'linkAudio') {
+                $vType = 'audio';
             }
             if (!in_array($vType, Video::$typeOptions)) {
                 $vType = 'video';

--- a/objects/youtubeUpload.json.php
+++ b/objects/youtubeUpload.json.php
@@ -1,14 +1,15 @@
 <?php
 error_reporting(0);
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoload.php';
+
 global $global, $config;
-if(!isset($global['systemRootPath'])){
+if (!isset($global['systemRootPath'])) {
     require_once '../videos/configuration.php';
 }
 require_once $global['systemRootPath'] . 'objects/video.php';
 $obj = new stdClass();
 $obj->success = false;
 require_once $global['systemRootPath'] . 'objects/functions.php';
-require_once $global['systemRootPath'] . 'objects/autoload.php';
 header('Content-Type: application/json');
 
 $obj = AVideoPlugin::getObjectData("LoginGoogle");
@@ -53,7 +54,7 @@ foreach ($_POST['id'] as $value) {
     if (isset($_SESSION[$tokenSessionKey])) {
         $client->setAccessToken($_SESSION[$tokenSessionKey]);
     }
-// Check to ensure that the access token was successfully acquired.
+    // Check to ensure that the access token was successfully acquired.
     if ($client->getAccessToken()) {
         try {
             // REPLACE this value with the path to the file you are uploading.
@@ -88,7 +89,12 @@ foreach ($_POST['id'] as $value) {
             $insertRequest = $youtube->videos->insert("status,snippet", $video);
             // Create a MediaFileUpload object for resumable uploads.
             $media = new Google_Http_MediaFileUpload(
-                    $client, $insertRequest, 'video/*', null, true, $chunkSizeBytes
+                $client,
+                $insertRequest,
+                'video/*',
+                null,
+                true,
+                $chunkSizeBytes
             );
             $media->setFileSize(filesize($videoPath));
             // Read the media file and upload it chunk by chunk.

--- a/plugin/ReportVideo/ReportVideo.php
+++ b/plugin/ReportVideo/ReportVideo.php
@@ -3,39 +3,47 @@
 global $global;
 require_once $global['systemRootPath'] . 'plugin/Plugin.abstract.php';
 require_once $global['systemRootPath'] . 'plugin/ReportVideo/Objects/videos_reported.php';
+require_once $global['systemRootPath'] . 'objects/autoload.php';
 
-class ReportVideo extends PluginAbstract {
-
-    public function getTags() {
+class ReportVideo extends PluginAbstract
+{
+    public function getTags()
+    {
         return array(
             PluginTags::$RECOMMENDED,
             PluginTags::$FREE,
         );
     }
-    public function getDescription() {
+    public function getDescription()
+    {
         return "Create a button to report videos with inapropriate content";
     }
 
-    public function getName() {
+    public function getName()
+    {
         return "ReportVideo";
     }
 
-    public function getUUID() {
+    public function getUUID()
+    {
         return "b5e223db-785b-4436-8f7b-f297860c9be0";
     }
 
-    public function getEmptyDataObject() {
+    public function getEmptyDataObject()
+    {
         $obj = new stdClass();
         $obj->emailLogo = "";
 
         return $obj;
     }
 
-    public function getPluginVersion() {
+    public function getPluginVersion()
+    {
         return "2.2";
     }
 
-    public function updateScript() {
+    public function updateScript()
+    {
         global $global;
         //update version 2.0
         if (AVideoPlugin::compareVersion($this->getName(), "2.0") < 0) {
@@ -55,7 +63,8 @@ class ReportVideo extends PluginAbstract {
         }
         return true;
     }
-    public function getWatchActionButton($videos_id) {
+    public function getWatchActionButton($videos_id)
+    {
         global $global, $video;
         if (!isVideo()) {
             return '';
@@ -74,14 +83,13 @@ class ReportVideo extends PluginAbstract {
         }
     }
 
-    function send($email, $subject, $body) {
+    public function send($email, $subject, $body)
+    {
         if (empty($email)) {
             return false;
         }
 
         global $global, $config;
-
-        require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';
 
         //Create a new PHPMailer instance
         $mail = new \PHPMailer\PHPMailer\PHPMailer;
@@ -105,8 +113,8 @@ class ReportVideo extends PluginAbstract {
         }
     }
 
-    private function replaceText($users_id, $videos_id, $text) {
-
+    private function replaceText($users_id, $videos_id, $text)
+    {
         $user = new User($users_id);
         $userName = $user->getNameIdentification();
 
@@ -120,7 +128,8 @@ class ReportVideo extends PluginAbstract {
         return str_replace($replace, $words, $text);
     }
 
-    private function getTemplateText($videos_id, $message) {
+    private function getTemplateText($videos_id, $message)
+    {
         global $global, $config;
         $obj = $this->getDataObject();
         $text = file_get_contents("{$global['systemRootPath']}plugin/ReportVideo/template.html");
@@ -139,7 +148,8 @@ class ReportVideo extends PluginAbstract {
         return str_replace($replace, $words, $text);
     }
 
-    function report($users_id, $videos_id) {
+    public function report($users_id, $videos_id)
+    {
         global $global, $config;
         // check if this user already report this video
         $report = VideosReported::getFromDbUserAndVideo($users_id, $videos_id);
@@ -166,9 +176,9 @@ class ReportVideo extends PluginAbstract {
 
                 if (!$videoOwnerSent && !$siteOwnerSent) {
                     $resp->msg = __("We could not notify anyone ({$email}, {$siteOwnerEmail}), but we marked it as a inapropriated");
-                } else if (!$videoOwnerSent) {
+                } elseif (!$videoOwnerSent) {
                     $resp->msg = __("We could not notify the video owner {$email}, but we marked it as a inapropriated");
-                } else if (!$siteOwnerSent) {
+                } elseif (!$siteOwnerSent) {
                     $resp->msg = __("We could not notify the video owner {$siteOwnerEmail}, but we marked it as a inapropriated");
                 } else {
                     $resp->error = false;
@@ -186,7 +196,8 @@ class ReportVideo extends PluginAbstract {
         return $resp;
     }
 
-    function block($users_id, $reported_users_id) {
+    public function block($users_id, $reported_users_id)
+    {
         global $global, $config;
         // check if this user already report this video
         $report = VideosReported::getFromDbUserAndReportedUser($users_id, $reported_users_id);
@@ -214,7 +225,8 @@ class ReportVideo extends PluginAbstract {
         return $resp;
     }
 
-    function unBlock($users_id, $reported_users_id) {
+    public function unBlock($users_id, $reported_users_id)
+    {
         global $global, $config;
         // check if this user already report this video
         $report = VideosReported::getFromDbUserAndReportedUser($users_id, $reported_users_id);
@@ -240,7 +252,8 @@ class ReportVideo extends PluginAbstract {
         return $resp;
     }
 
-    static function isBlocked($reported_users_id, $users_id = 0) {
+    public static function isBlocked($reported_users_id, $users_id = 0)
+    {
         global $global, $config;
         if (empty($users_id)) {
             $users_id = User::getId();
@@ -251,7 +264,8 @@ class ReportVideo extends PluginAbstract {
         return in_array($reported_users_id, $reportedUsersId);
     }
 
-    static function getAllReportedUsersIdFromUser($users_id=0) {
+    public static function getAllReportedUsersIdFromUser($users_id=0)
+    {
         if (empty($users_id)) {
             $users_id = User::getId();
         }
@@ -259,7 +273,8 @@ class ReportVideo extends PluginAbstract {
         return VideosReported::getAllReportedUsersIdFromUser($users_id);
     }
 
-    static function buttonBlockUser($users_id) {
+    public static function buttonBlockUser($users_id)
+    {
         if ($users_id == User::getId()) {
             return '';
         }
@@ -273,7 +288,8 @@ class ReportVideo extends PluginAbstract {
         return $button;
     }
 
-    static function actionButtonBlockUser($users_id) {
+    public static function actionButtonBlockUser($users_id)
+    {
         if ($users_id == User::getId()) {
             return '';
         }
@@ -286,5 +302,4 @@ class ReportVideo extends PluginAbstract {
         echo $variable;
         return $button;
     }
-
 }

--- a/plugin/YPTWallet/YPTWallet.php
+++ b/plugin/YPTWallet/YPTWallet.php
@@ -5,36 +5,43 @@ require_once $global['systemRootPath'] . 'plugin/Plugin.abstract.php';
 require_once $global['systemRootPath'] . 'plugin/Plugin.abstract.php';
 require_once $global['systemRootPath'] . 'plugin/YPTWallet/Objects/Wallet.php';
 require_once $global['systemRootPath'] . 'plugin/YPTWallet/Objects/Wallet_log.php';
+require_once $global['systemRootPath'] . 'objects/autoload.php';
 
-class YPTWallet extends PluginAbstract {
-
+class YPTWallet extends PluginAbstract
+{
     const MANUAL_WITHDRAW = "Manual Withdraw Funds";
     const MANUAL_ADD = "Manual Add Funds";
 
-    public function getTags() {
+    public function getTags()
+    {
         return array(
             PluginTags::$MONETIZATION,
             PluginTags::$NETFLIX,
             PluginTags::$FREE,
         );
     }
-    public function getDescription() {
+    public function getDescription()
+    {
         return "Wallet for AVideo";
     }
 
-    public function getName() {
+    public function getName()
+    {
         return "YPTWallet";
     }
 
-    public function getUUID() {
+    public function getUUID()
+    {
         return "2faf2eeb-88ac-48e1-a098-37e76ae3e9f3";
     }
 
-    public function getPluginVersion() {
+    public function getPluginVersion()
+    {
         return "3.1";
     }
 
-    public function getEmptyDataObject() {
+    public function getEmptyDataObject()
+    {
         $obj = new stdClass();
         $obj->decimalPrecision = 2;
         $obj->wallet_button_title = "My Wallet";
@@ -86,23 +93,27 @@ class YPTWallet extends PluginAbstract {
         return $obj;
     }
 
-    public function getBalance($users_id) {
+    public function getBalance($users_id)
+    {
         $wallet = self::getWallet($users_id);
         return $wallet->getBalance();
     }
 
-    public function getBalanceText($users_id) {
+    public function getBalanceText($users_id)
+    {
         $balance = $this->getBalanceFormated($users_id);
         return self::formatCurrency($balance);
     }
 
-    public function getBalanceFormated($users_id) {
+    public function getBalanceFormated($users_id)
+    {
         $balance = $this->getBalance($users_id);
         $obj = $this->getDataObject();
         return number_format($balance, $obj->decimalPrecision);
     }
 
-    static function formatCurrency($value, $addHTML=false, $doNotUseVirtualCurrency = false) {
+    public static function formatCurrency($value, $addHTML=false, $doNotUseVirtualCurrency = false)
+    {
         $value = floatval($value);
         $obj = AVideoPlugin::getObjectData('YPTWallet');
         $currency_symbol = $obj->currency_symbol;
@@ -115,38 +126,42 @@ class YPTWallet extends PluginAbstract {
         }
         $value = number_format($value, $decimalPrecision);
 
-        if($addHTML){
+        if ($addHTML) {
             return "{$currency_symbol} <span class=\"walletBalance\">{$value}</span> {$currency}";
-        }else{
+        } else {
             return "{$currency_symbol} {$value} {$currency}";
         }
     }
 
-    static function getStep($doNotUseVirtualCurrency = false) {
+    public static function getStep($doNotUseVirtualCurrency = false)
+    {
         $obj = AVideoPlugin::getObjectData('YPTWallet');
         $decimalPrecision = $obj->decimalPrecision;
         if ($obj->virtual_currency_enable) {
             $decimalPrecision = $obj->virtual_currency_decimalPrecision;
         }
-        if(empty($decimalPrecision)){
+        if (empty($decimalPrecision)) {
             return 1;
         }
         return "0.".str_repeat("0", $decimalPrecision-1)."1";
     }
 
-    static function formatFloat($value) {
+    public static function formatFloat($value)
+    {
         $value = floatval($value);
         $obj = AVideoPlugin::getObjectData('YPTWallet');
         return number_format($value, $obj->decimalPrecision);
     }
 
-    static function getWallet($users_id) {
+    public static function getWallet($users_id)
+    {
         $wallet = new Wallet(0);
         $wallet->setUsers_id($users_id);
         return $wallet;
     }
 
-    public function getOrCreateWallet($users_id) {
+    public function getOrCreateWallet($users_id)
+    {
         $wallet = new Wallet(0);
         $wallet->setUsers_id($users_id);
         if (empty($wallet->getId())) {
@@ -156,7 +171,8 @@ class YPTWallet extends PluginAbstract {
         return $wallet;
     }
 
-    function getAllUsers($activeOnly = true) {
+    public function getAllUsers($activeOnly = true)
+    {
         global $global;
         $sql = "SELECT w.*, u.*, u.id as user_id, IFNULL(balance, 0) as balance FROM users u "
                 . " LEFT JOIN wallet w ON u.id = w.users_id WHERE 1=1 ";
@@ -189,7 +205,8 @@ class YPTWallet extends PluginAbstract {
         return $user;
     }
 
-    static function getTotalBalance() {
+    public static function getTotalBalance()
+    {
         global $global;
         $sql = "SELECT sum(balance) as total FROM wallet ";
 
@@ -206,19 +223,22 @@ class YPTWallet extends PluginAbstract {
         return 0;
     }
 
-    static function getTotalBalanceText() {
+    public static function getTotalBalanceText()
+    {
         $value = self::getTotalBalance();
         return self::formatCurrency($value);
     }
 
-    public function getHistory($user_id) {
+    public function getHistory($user_id)
+    {
         $wallet = self::getWallet($user_id);
         $log = new WalletLog(0);
         $rows = $log->getAllFromWallet($wallet->getId());
         return $rows;
     }
 
-    static function exchange($value){
+    public static function exchange($value)
+    {
         $obj = AVideoPlugin::getObjectData('YPTWallet');
         $value = floatval($value);
         $virtual_currency_exchange_rate = floatval($obj->virtual_currency_exchange_rate);
@@ -236,10 +256,11 @@ class YPTWallet extends PluginAbstract {
      * @param type $json_data
      * @param type $mainWallet_user_id A user ID where the money comes from and where the money goes for
      */
-    public function addBalance($users_id, $value, $description = "", $json_data = "{}", $mainWallet_user_id = 0, $noNotExchangeValue = false) {
+    public function addBalance($users_id, $value, $description = "", $json_data = "{}", $mainWallet_user_id = 0, $noNotExchangeValue = false)
+    {
         global $global;
         $obj = $this->getDataObject();
-        if(empty($noNotExchangeValue) && !empty($obj->virtual_currency_enable)){
+        if (empty($noNotExchangeValue) && !empty($obj->virtual_currency_enable)) {
             $originalValue = $value;
             $value = self::exchange($value);
 
@@ -272,7 +293,8 @@ class YPTWallet extends PluginAbstract {
         //_error_log("YPTWallet::addBalance $wallet_id, $value, $description, $json_data");
     }
 
-    public function saveBalance($users_id, $value) {
+    public function saveBalance($users_id, $value)
+    {
         if (!User::isAdmin()) {
             return false;
         }
@@ -284,7 +306,8 @@ class YPTWallet extends PluginAbstract {
         WalletLog::addLog($wallet_id, $value, $description, "{}", "success", "saveBalance");
     }
 
-    static function transferBalanceToSiteOwner($users_id_from, $value, $description = "", $forceTransfer = false) {
+    public static function transferBalanceToSiteOwner($users_id_from, $value, $description = "", $forceTransfer = false)
+    {
         $obj = AVideoPlugin::getObjectData('YPTWallet');
         if (empty($obj->manualWithdrawFundsTransferToUserId)) {
             _error_log("YPTWallet::transferBalanceToSiteOwner site owner is not defined in the plugin, define it on the option manualWithdrawFundsTransferToUserId", AVideoLog::$ERROR);
@@ -292,26 +315,30 @@ class YPTWallet extends PluginAbstract {
         return self::transferBalance($users_id_from, $obj->manualWithdrawFundsTransferToUserId, $value, $description, $forceTransfer);
     }
 
-    static function transferBalanceFromSiteOwner($users_id_from, $value, $description = "", $forceTransfer = false) {
+    public static function transferBalanceFromSiteOwner($users_id_from, $value, $description = "", $forceTransfer = false)
+    {
         $obj = AVideoPlugin::getObjectData('YPTWallet');
         return self::transferBalance($obj->manualWithdrawFundsTransferToUserId, $users_id_from, $value, $description, $forceTransfer);
     }
 
-    static function transferBalanceFromMeToSiteOwner($value) {
+    public static function transferBalanceFromMeToSiteOwner($value)
+    {
         if (!User::isLogged()) {
             return false;
         }
         return self::transferBalanceToSiteOwner(User::getId(), $value);
     }
 
-    static function transferBalanceFromOwnerToMe($value) {
+    public static function transferBalanceFromOwnerToMe($value)
+    {
         if (!User::isLogged()) {
             return false;
         }
         return self::transferBalanceFromSiteOwner(User::getId(), $value);
     }
 
-    static function transferBalance($users_id_from, $users_id_to, $value, $forceDescription = "", $forceTransfer = false) {
+    public static function transferBalance($users_id_from, $users_id_to, $value, $forceDescription = "", $forceTransfer = false)
+    {
         global $global;
         _error_log("transferBalance: $users_id_from, $users_id_to, $value, $forceDescription, $forceTransfer");
         if (!User::isAdmin()) {
@@ -362,7 +389,8 @@ class YPTWallet extends PluginAbstract {
         return true;
     }
 
-    public function getHTMLMenuRight() {
+    public function getHTMLMenuRight()
+    {
         global $global;
         if (!User::isLogged()) {
             return "";
@@ -374,7 +402,8 @@ class YPTWallet extends PluginAbstract {
         include $global['systemRootPath'] . 'plugin/YPTWallet/view/menuRight.php';
     }
 
-    static function getAvailablePayments() {
+    public static function getAvailablePayments()
+    {
         global $global;
 
         if (!User::isLogged()) {
@@ -404,7 +433,8 @@ class YPTWallet extends PluginAbstract {
         return true;
     }
 
-    static function getAvailableRecurrentPayments() {
+    public static function getAvailableRecurrentPayments()
+    {
         global $global;
 
         if (!User::isLogged()) {
@@ -433,7 +463,8 @@ class YPTWallet extends PluginAbstract {
         }
     }
 
-    static function getAvailablePlugins() {
+    public static function getAvailablePlugins()
+    {
         $dir = self::getPluginDir();
         $dirs = scandir($dir);
         $plugins = array();
@@ -449,7 +480,8 @@ class YPTWallet extends PluginAbstract {
         return $plugins;
     }
 
-    static function getEnabledPlugins() {
+    public static function getEnabledPlugins()
+    {
         global $global;
         $plugins = self::getAvailablePlugins();
         $wallet = new YPTWallet();
@@ -464,7 +496,8 @@ class YPTWallet extends PluginAbstract {
         return $plugins;
     }
 
-    static function getPluginDataObject($pluginName) {
+    public static function getPluginDataObject($pluginName)
+    {
         $dir = self::getPluginDir();
         $file = $dir . "/{$pluginName}/{$pluginName}.php";
         if (file_exists($file)) {
@@ -476,13 +509,15 @@ class YPTWallet extends PluginAbstract {
         return array();
     }
 
-    static function getPluginDir() {
+    public static function getPluginDir()
+    {
         global $global;
         $dir = $global['systemRootPath'] . "plugin/YPTWallet/plugins";
         return $dir;
     }
 
-    function sendEmails($emailsArray, $subject, $message) {
+    public function sendEmails($emailsArray, $subject, $message)
+    {
         global $global, $config;
         $siteTitle = $config->getWebSiteTitle();
         $footer = $config->getWebSiteTitle();
@@ -490,7 +525,8 @@ class YPTWallet extends PluginAbstract {
         return $this->send($emailsArray, $subject, $body);
     }
 
-    private function replaceTemplateText($siteTitle, $footer, $message) {
+    private function replaceTemplateText($siteTitle, $footer, $message)
+    {
         global $global, $config;
         $text = file_get_contents("{$global['systemRootPath']}plugin/YPTWallet/template.html");
         $words = array($siteTitle, $footer, $message);
@@ -499,15 +535,14 @@ class YPTWallet extends PluginAbstract {
         return str_replace($replace, $words, $text);
     }
 
-    private function send($emailsArray, $subject, $body) {
+    private function send($emailsArray, $subject, $body)
+    {
         if (empty($emailsArray)) {
             return false;
         }
         $emailsArray = array_unique($emailsArray);
 
         global $global, $config;
-
-        require_once $global['systemRootPath'] . 'objects/include_phpmailer.php';
 
         //Create a new PHPMailer instance
         $mail = new \PHPMailer\PHPMailer\PHPMailer;
@@ -541,7 +576,8 @@ class YPTWallet extends PluginAbstract {
      * @param type $new_status
      * return true if balance is enought
      */
-    function processStatus($wallet_log_id, $new_status) {
+    public function processStatus($wallet_log_id, $new_status)
+    {
         $obj = $this->getDataObject();
         $walletLog = new WalletLog($wallet_log_id);
         $wallet = new Wallet($walletLog->getWallet_id());
@@ -562,23 +598,23 @@ class YPTWallet extends PluginAbstract {
                     return self::transferBalance($wallet->getUsers_id(), $obj->manualWithdrawFundsTransferToUserId, $walletLog->getValue());
                 }
             }
-        } else if ($walletLog->getType() == self::MANUAL_ADD) {
+        } elseif ($walletLog->getType() == self::MANUAL_ADD) {
             if ($oldStatus == "pending") {
                 if ($new_status == "canceled") {
                     // do nothing
                     return true;
-                } else if ($new_status == "success") {
+                } elseif ($new_status == "success") {
                     // transfer the value
                     return self::transferBalance($obj->manualAddFundsTransferFromUserId, $wallet->getUsers_id(), $walletLog->getValue());
                 }
-            } else if ($oldStatus == "success") {
+            } elseif ($oldStatus == "success") {
                 //get the money back
                 return self::transferBalance($wallet->getUsers_id(), $obj->manualAddFundsTransferFromUserId, $walletLog->getValue());
-            } else if ($oldStatus == "canceled") {
+            } elseif ($oldStatus == "canceled") {
                 if ($new_status == "pending") {
                     // do nothing
                     return true;
-                } else if ($new_status == "success") {
+                } elseif ($new_status == "success") {
                     // transfer the value
                     return self::transferBalance($obj->manualAddFundsTransferFromUserId, $wallet->getUsers_id(), $walletLog->getValue());
                 }
@@ -587,18 +623,20 @@ class YPTWallet extends PluginAbstract {
         return true;
     }
 
-    static function getUserBalance($users_id=0){
-        if(empty($users_id)){
+    public static function getUserBalance($users_id=0)
+    {
+        if (empty($users_id)) {
             $users_id = User::getId();
         }
-        if(empty($users_id)){
+        if (empty($users_id)) {
             return 0;
         }
         $wallet = self::getWallet($users_id);
         return $wallet->getBalance();
     }
 
-    public function getFooterCode() {
+    public function getFooterCode()
+    {
         global $global;
         $obj = $this->getDataObject();
         $js = "";
@@ -606,5 +644,4 @@ class YPTWallet extends PluginAbstract {
 
         return $js;
     }
-
 }


### PR DESCRIPTION
Since we already have Composer integration and dependencies properly mapped to the Composer autoloader, it may be slightly easier and cleaner for future maintainability to use the Composer autoloader instead of manual loading those particular dependencies (when possible, and only referring here to the dependencies mentioned in the `composer.json` file, of course).

This PR implements that (plus a little minor refactoring at the affected files).

This should also resolve (in a slightly better manner) the PHPMailer problems reported a few days ago (replacing the need for the `include_phpmailer.php` file).