### PR TITLE
Permissions Plugin: Disabling UI buttons when the plugin is not installed

### DIFF
--- a/plugin/Permissions/Permissions.php
+++ b/plugin/Permissions/Permissions.php
@@ -72,8 +72,18 @@ class Permissions extends PluginAbstract {
         return '<a href="plugin/Permissions/View/editor.php" class="btn btn-primary btn-sm btn-xs btn-block"><i class="fa fa-edit"></i> Edit</a>';
     }
 
-    static function getForm() {
+    static function getForm() {        
         global $global;
+                
+        $disabled = "";
+        if (!Users_groups_permissions::isTableInstalled()) {
+            $disabled = " disabled='disabled' ";
+            echo "<div class=\"alert alert-danger\">"
+            . "<span class=\"fa fa-info-circle\"></span> "
+            . __("The Permissions Plugin is not installed. Please install it if you want to customize the permissions.")
+            . "</div>";
+        }        
+
         $plugins = Plugin::getAllEnabled();
         foreach ($plugins as $value) {
             $row = Plugin::getPluginByName($value['dirName']);
@@ -86,9 +96,9 @@ class Permissions extends PluginAbstract {
                     }
                     echo "<div class=\"checkbox\">"
                     . "<label data-toggle=\"tooltip\" title=\"" . addcslashes($value->getDescription(), '"') . "\">"
-                    . "<input type=\"checkbox\" name=\"permissions[" . $value->getClassName() . "][]\" value=\"" . $value->getType() . "\" class=\"permissions " . $value->getClassName() . "\">" . $value->getName() . " "
+                    . "<input ".$disabled." type=\"checkbox\" name=\"permissions[" . $value->getClassName() . "][]\" value=\"" . $value->getType() . "\" class=\"permissions " . $value->getClassName() . "\">" . $value->getName() . " "
                     . "</label>"
-                    . " <button type='button' class='btn btn-xs pull-right' data-toggle=\"tooltip\" title=\"" . $value->getClassName() . " Plugin\" onclick=\"pluginPermissionsBtn({$row['id']})\">(" . $value->getClassName() . ")</button>"
+                    . " <button ".$disabled." type='button' class='btn btn-xs pull-right' data-toggle=\"tooltip\" title=\"" . $value->getClassName() . " Plugin\" onclick=\"pluginPermissionsBtn({$row['id']})\">(" . $value->getClassName() . ")</button>"
                     . "</div>";
                 }
             }

--- a/view/managerPlugins_body.php
+++ b/view/managerPlugins_body.php
@@ -486,7 +486,11 @@ $uuidJSCondition = implode(" && ", $rowId);
                         }
                     }
                     if (row.hasOwnProperty("permissions") && row.permissions.length) {
-                        txt += '<button type="button" class="btn btn-xs btn-default btn-block" onclick="pluginPermissionsBtn(' + row.id + ')" data-toggle="tooltip" data-placement="right" title="<?php echo __('User Groups Permissions'); ?>"><span class="fa fa-users" aria-hidden="true"></span> <?php echo __('User Groups Permissions'); ?></button>';
+                        var disabled = "";
+                        if (!row.isPluginTablesInstalled) {
+                            disabled = ' disabled="disabled" ';
+                        }
+                        txt += '<button ' + disabled + ' type="button" class="btn btn-xs btn-default btn-block" onclick="pluginPermissionsBtn(' + row.id + ')" data-toggle="tooltip" data-placement="right" title="<?php echo __('User Groups Permissions'); ?>"><span class="fa fa-users" aria-hidden="true"></span> <?php echo __('User Groups Permissions'); ?></button>';
                     }
 
                     return txt;


### PR DESCRIPTION
When the **Permissions Plugin** tables aren't installed, the UI isn't working properly. Indeed, when the `users_groups_permissions` table is missing, all the actions made in the screen aren't taken into account. This is really confusing for the end-user.

Now, the `User Groups Permissions` is disabled in the `Plugins` page:

![permissions1](https://user-images.githubusercontent.com/15776845/104239245-7e702280-545a-11eb-8da7-90c66683c9a1.jpg)

In the `Groups` page, all the buttons are disabled and a message is shown:

![permissions2](https://user-images.githubusercontent.com/15776845/104239247-7f08b900-545a-11eb-8f59-bcc9e25c13fd.jpg)
