### PR TITLE
Add active and encoding status

### DIFF
--- a/install/database.sql
+++ b/install/database.sql
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS `videos` (
   `views_count_50` INT(11) NULL DEFAULT 0,
   `views_count_75` INT(11) NULL DEFAULT 0,
   `views_count_100` INT(11) NULL DEFAULT 0,
-  `status` ENUM('a', 'i', 'e', 'x', 'd', 'xmp4', 'xwebm', 'xmp3', 'xogg', 'ximg', 'u', 'p', 't') NOT NULL DEFAULT 'e' COMMENT 'a = active\ni = inactive\ne = encoding\nx = encoding error\nd = downloading\nu = Unlisted\np = private\nxmp4 = encoding mp4 error \nxwebm = encoding webm error \nxmp3 = encoding mp3 error \nxogg = encoding ogg error \nximg = get image error\nt = Transfering' ,
+  `status` ENUM('a', 'k', 'i', 'e', 'x', 'd', 'xmp4', 'xwebm', 'xmp3', 'xogg', 'ximg', 'u', 'p', 't') NOT NULL DEFAULT 'e' COMMENT 'a = active\nk = active and encoding\ni = inactive\ne = encoding\nx = encoding error\nd = downloading\nu = Unlisted\np = private\nxmp4 = encoding mp4 error \nxwebm = encoding webm error \nxmp3 = encoding mp3 error \nxogg = encoding ogg error \nximg = get image error\nt = Transfering' ,
   `created` DATETIME NOT NULL,
   `modified` DATETIME NOT NULL,
   `users_id` INT NOT NULL,

--- a/locale/fr.php
+++ b/locale/fr.php
@@ -16,6 +16,7 @@ $t['AVideo URL'] = "AVideo URL";
 $t['About AVideo!'] = "À propos de AVideo !";
 $t['About'] = "À propos";
 $t['Activate'] = "Activer";
+$t['Active and encoding'] = "Actif et codage";
 $t['Active Users'] = 'Utilisateurs actifs';
 $t['Active'] = "Actif";
 $t['Ad Title'] = "Ajouter un titre";

--- a/objects/aVideoEncoder.json.php
+++ b/objects/aVideoEncoder.json.php
@@ -61,8 +61,13 @@ $status = $video->getStatus();
 // if status is not unlisted
 if ($status !== 'u' && $status !== 'a') {
     if (empty($advancedCustom->makeVideosInactiveAfterEncode)) {
-        // set active
-        $video->setStatus('a');
+        // set active or active+encoding
+        if ($_POST['keepEncoding'] == '1') {
+            $video->setStatus('k');
+        } else {
+            $video->setStatus('a');
+        }
+
     } elseif (empty($advancedCustom->makeVideosUnlistedAfterEncode)) {
         // set active
         $video->setStatus('u');
@@ -176,6 +181,7 @@ if (!empty($_POST['usergroups_id'])) {
 $obj->error = false;
 $obj->video_id = $video_id;
 _error_log("aVideoEncoder.json: Files Received for video {$video_id}: " . $video->getTitle());
+fprintf(fopen("/tmp/log", "a"), "aVideoEncoder.json returns\n%s\n", json_encode($obj));
 die(json_encode($obj));
 
 /*

--- a/objects/aVideoEncoder.json.php
+++ b/objects/aVideoEncoder.json.php
@@ -181,7 +181,6 @@ if (!empty($_POST['usergroups_id'])) {
 $obj->error = false;
 $obj->video_id = $video_id;
 _error_log("aVideoEncoder.json: Files Received for video {$video_id}: " . $video->getTitle());
-fprintf(fopen("/tmp/log", "a"), "aVideoEncoder.json returns\n%s\n", json_encode($obj));
 die(json_encode($obj));
 
 /*

--- a/objects/video.php
+++ b/objects/video.php
@@ -2246,7 +2246,6 @@ if (!class_exists('Video')) {
             if (empty($type) || $type === "status") {
                 $objTag = new stdClass();
                 $objTag->label = __("Status");
-error_log("status = ".$video->getStatus());
                 switch ($video->getStatus()) {
                     case 'a':
                         $objTag->type = "success";

--- a/objects/video.php
+++ b/objects/video.php
@@ -56,6 +56,7 @@ if (!class_exists('Video')) {
         private $filesize;
         public static $statusDesc = array(
             'a' => 'active',
+            'k' => 'active and encoding',
             'i' => 'inactive',
             'e' => 'encoding',
             'x' => 'encoding error',
@@ -1057,7 +1058,7 @@ if (!class_exists('Video')) {
             } elseif ($status == "viewableNotUnlisted") {
                 $sql .= " AND v.status IN ('" . implode("','", Video::getViewableStatus(false)) . "')";
             } elseif ($status == "publicOnly") {
-                $sql .= " AND v.status = 'a' AND (SELECT count(id) FROM videos_group_view as gv WHERE gv.videos_id = v.id ) = 0";
+                $sql .= " AND v.status IN ('a', 'k') AND (SELECT count(id) FROM videos_group_view as gv WHERE gv.videos_id = v.id ) = 0";
             } elseif (!empty($status)) {
                 $sql .= " AND v.status = '{$status}'";
             }
@@ -1601,6 +1602,7 @@ if (!class_exists('Video')) {
         {
             /**
               a = active
+              k = active and encoding
               i = inactive
               e = encoding
               x = encoding error
@@ -1611,7 +1613,7 @@ if (!class_exists('Video')) {
               xmp3 = encoding mp3 error
               xogg = encoding ogg error
              */
-            $viewable = array('a', 'xmp4', 'xwebm', 'xmp3', 'xogg');
+            $viewable = array('a', 'k', 'xmp4', 'xwebm', 'xmp3', 'xogg');
             if ($showUnlisted) {
                 $viewable[] = "u";
             } elseif (!empty($_GET['videoName'])) {
@@ -2244,10 +2246,15 @@ if (!class_exists('Video')) {
             if (empty($type) || $type === "status") {
                 $objTag = new stdClass();
                 $objTag->label = __("Status");
+error_log("status = ".$video->getStatus());
                 switch ($video->getStatus()) {
                     case 'a':
                         $objTag->type = "success";
                         $objTag->text = __("Active");
+                        break;
+                    case 'k':
+                        $objTag->type = "success";
+                        $objTag->text = __("Active and encoding");
                         break;
                     case 'i':
                         $objTag->type = "warning";

--- a/updatedb/updateDb.v9.8.sql
+++ b/updatedb/updateDb.v9.8.sql
@@ -1,0 +1,13 @@
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
+
+ALTER TABLE `videos` 
+MODIFY COLUMN status 
+ENUM('a', 'k', 'i', 'e', 'x', 'd', 'xmp4', 'xwebm', 'xmp3', 'xogg', 'ximg', 'u', 'p', 't') NOT NULL DEFAULT 'e' COMMENT 'a = active\nk = active and encofing\ni = inactive\ne = encoding\nx = encoding error\nd = downloading\nu = Unlisted\np = private\nxmp4 = encoding mp4 error \nxwebm = encoding webm error \nxmp3 = encoding mp3 error \nxogg = encoding ogg error \nximg = get image error\nt = Transfering';
+
+UPDATE configurations SET  version = '9.8', modified = now() WHERE id = 1;
+
+SET SQL_MODE=@OLD_SQL_MODE;
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;

--- a/view/managerVideos_body.php
+++ b/view/managerVideos_body.php
@@ -1770,7 +1770,7 @@ if (User::isAdmin()) {
 
                                                         if (row.status == "i") {
                                                             status = inactiveBtn;
-                                                        } else if (row.status == "a") {
+                                                        } else if (row.status == "a"  || row.status == "k") {
                                                             status = activeBtn;
                                                         } else if (row.status == "u") {
                                                             status = unlistedBtn;


### PR DESCRIPTION
This is for the progressiveUpload option of Avideo-Encoder, where the
encoded videos are sent as soon as they are encoded, and not in a
final batch. The video is immediatly avaiable but we need to display
that more encoded videos are to come.
