### PR TITLE
Update nginx.conf

### DIFF
--- a/plugin/Live/install/nginx.conf
+++ b/plugin/Live/install/nginx.conf
@@ -7,6 +7,7 @@ worker_processes  1;
     rtmp {
             server {
                     listen 1935;
+                    buflen 2s;
                     allow play all;
                     #creates our "live" full-resolution HLS videostream from our incoming encoder stream and tells where to put the HLS video manifest and video fragments
                     application live {
@@ -22,10 +23,10 @@ worker_processes  1;
                             on_play http://localhost/AVideo/plugin/Live/on_play.php;
                             on_record_done http://localhost/AVideo/plugin/Live/on_record_done.php;
 
-                            #exec ffmpeg -i rtmp://localhost/live/$name 
-                            #    -c:a aac -strict -2 -b:a 96k -c:v libx264 -vf scale=-2:240 -g 48 -keyint_min 48 -sc_threshold 0 -bf 3 -b_strategy 2 -b:v 400k -maxrate 700k -bufsize 1200k -b:a 96k -r 20 -f hls -hls_time 6 -hls_list_size 0 -f flv rtmp://localhost/adaptive/$name_low  
-                            #    -c:a aac -strict -2 -b:a 128k -c:v libx264 -vf scale=-2:480 -g 48 -keyint_min 48 -sc_threshold 0 -bf 3 -b_strategy 2 -b:v 1200k -maxrate 2100k -bufsize 2400k -b:a 128k -f hls -hls_time 6 -hls_list_size 0 -f flv rtmp://localhost/adaptive/$name_mid  
-                            #    -c:a aac -strict -2 -b:a 128k -c:v libx264 -vf scale=-2:720 -g 48 -keyint_min 48 -sc_threshold 0 -bf 3 -b_strategy 2 -b:v 2400k -maxrate 4200k -bufsize 100000k -b:a 128k -f hls -hls_time 6 -hls_list_size 0 -f flv rtmp://localhost/adaptive/$name_hi;
+                            #exec ffmpeg -re -i rtmp://localhost/live/$name 
+                            #    -c:a aac -strict -2 -b:a 96k -c:v libx264 -vf scale=-2:240 -re 20 -g 40 -keyint_min 40 -sc_threshold 0 -bf 3 -b_strategy 2 -b:v 400k -maxrate 700k -bufsize 1400k -b:a 96k -f hls -hls_time 2 -hls_list_size 0 -f flv rtmp://localhost/adaptive/$name_low  
+                            #    -c:a aac -strict -2 -b:a 128k -c:v libx264 -vf scale=-2:480 -re 30 -g 60 -keyint_min 48 -sc_threshold 0 -bf 3 -b_strategy 2 -b:v 1200k -maxrate 2100k -bufsize 4200k -b:a 128k -f hls -hls_time 2 -hls_list_size 0 -f flv rtmp://localhost/adaptive/$name_mid  
+                            #    -c:a aac -strict -2 -b:a 128k -c:v libx264 -vf scale=-2:720 -re 30 -g 60 -keyint_min 48 -sc_threshold 0 -bf 3 -b_strategy 2 -b:v 2400k -maxrate 3000k -bufsize 6000k -b:a 128k -f hls -hls_time 2 -hls_list_size 0 -f flv rtmp://localhost/adaptive/$name_hi;
 
 
                             #recorder video{
@@ -48,9 +49,9 @@ worker_processes  1;
                     #    allow publish 127.0.0.1;
                     #    deny publish all;
 
-                    #    hls_variant _low BANDWIDTH=400000;
-                    #    hls_variant _mid BANDWIDTH=2100000;
-                    #    hls_variant _hi  BANDWIDTH=4200000;
+                    #    hls_variant _low BANDWIDTH=900000;
+                    #    hls_variant _mid BANDWIDTH=2400000;
+                    #    hls_variant _hi  BANDWIDTH=3500000;
                     #}
             }
     }


### PR DESCRIPTION
**-hls_time** is really bad on most of the script encoder that we have in this project . I think developers doesn't understand it well . This value has no meaning what so ever when not indicated correctly and the script will give errors on playlist and in cases completally ignore it ! Most the issues related to seeking on the videos are related to this . I hope with this explanation we can have better implementation in the future related to HLS plugin .
 

1. You can't set hls_time without indicating a valid GOP ( -g )
2. GOP must be your output frame rate * 2 ( most cases , with latency of 2 seconds ; default )
3. The hls_time formula :  GOP/FrameRates=hls_time

Example ;  
`-r 60 -g 120 -hls_time 2 ` ( **valid** values )
`-r 60 -g 240 -hls_time 4` (**valid** value , HIGH latency stream )
`-r 30 -g 30 -hls_time 1` ( **valid** value , LOW latency stream )

`-r 20 -g 48 -hls_time 6` ( **wrong** values , a lot of buffering and weird/unstable hls_playlist , if not completely ignored . The seek bar gonna just be confused ).

modification based on your information ; 
https://trac.ffmpeg.org/wiki/EncodingForStreamingSites
https://github.com/arut/nginx-rtmp-module/wiki/Directives#buflen
https://trac.ffmpeg.org/wiki/Limiting%20the%20output%20bitrate