### PR TITLE
Collect and store video metadata from ffprobe

### DIFF
--- a/install/database.sql
+++ b/install/database.sql
@@ -189,6 +189,29 @@ ENGINE = InnoDB;
 
 
 -- -----------------------------------------------------
+-- Table `videos_metadata`
+-- Constraint on videos.id commented out for now because it bugs
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `videos_metadata` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `videos_id` INT NOT NULL,
+  `resolution` VARCHAR(12) NOT NULL,
+  `format` VARCHAR(12) NOT NULL,
+  `stream_id` INT NOT NULL,
+  `name` VARCHAR(128) NOT NULL,
+  `value` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE (`videos_id`, `resolution`, `format`, `stream_id`, `name`),
+  INDEX `fk_videos_metadata_videos1_idx` (`videos_id` ASC)
+  -- CONSTRAINT `fk_videos_metadata_videos1`
+  --   FOREIGN KEY (`videos_id`)
+  --   REFERENCES `videos` (`id`)
+  --   ON DELETE CASCADE
+  --   ON UPDATE CASCADE
+) ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
 -- Table `comments`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `comments` (

--- a/install/metadata.php
+++ b/install/metadata.php
@@ -1,0 +1,26 @@
+<?php
+
+
+$global['systemRootPath'] = dirname(dirname(__FILE__)) . '/';
+
+require_once $global['systemRootPath'] . 'videos/configuration.php';
+require_once $global['systemRootPath'] . 'objects/functions.php';
+require_once $global['systemRootPath'] . 'objects/video.php';
+require_once $global['systemRootPath'] . 'objects/videoMetadata.php';
+
+/**
+ * @brief return true if running in CLI, false otherwise
+ * if is set $_GET['ignoreCommandLineInterface'] will return false
+ * @return boolean
+ */
+
+if (!isCommandLineInterface()) {
+    return die('Command Line only');
+}
+
+$videos = Video::getAllVideosLight(NULL);
+foreach ($videos as $v) {
+    VideoMetadata::importMetadataFromVideo($v['id']);
+}
+
+?>

--- a/objects/aVideoEncoder.json.php
+++ b/objects/aVideoEncoder.json.php
@@ -10,6 +10,7 @@ if (!isset($global['systemRootPath'])) {
 }
 require_once $global['systemRootPath'] . 'objects/user.php';
 require_once $global['systemRootPath'] . 'objects/video.php';
+require_once $global['systemRootPath'] . 'objects/videoMetadata.php';
 
 if (empty($_POST)) {
     $obj->msg = __("Your POST data is empty may be your vide file is too big for the host");
@@ -145,6 +146,7 @@ if (!empty($_FILES['video']['tmp_name'])) {
 
     _error_log("aVideoEncoder.json: receiving video upload to {$filename} filesize=" . ($fsize) . " (" . humanFileSize($fsize) . ")" . json_encode($_FILES));
     decideMoveUploadedToVideos($_FILES['video']['tmp_name'], $filename);
+    VideoMetadata::importMetadata($video->getId(), $resolution, $_POST['format']);
 } else {
     // set encoding
     $video->setStatus('e');

--- a/objects/functions.php
+++ b/objects/functions.php
@@ -5910,3 +5910,103 @@ function getImageTransparent1pxURL(){
     global $global;
     return "{$global['webSiteRootURL']}view/img/transparent1px.png";
 }
+
+function resolution_to_color($width, $height) {
+    $w = max($width, $height);
+    $h = min($width, $height);
+
+    $color = "#ccc";
+    if ($w * 1.02 > 1280 && $h * 1.02 > 720) /* HD */
+        $color = "#cc8";
+    if ($w * 1.02 > 1920 && $h * 1.02 > 1080) /* FHD */
+        $color = "#c88";
+    if ($w * 1.02 > 3840 && $h * 1.02 > 2160) /* 4K */
+        $color = "#c8c";
+    if ($w * 1.02 > 7680 && $h * 1.02 > 4320) /* 8K */
+        $color = "#000";
+
+    return $color;
+}
+
+function resolution_to_name($width, $height, $approx = true) {
+    /* Reference https://en.wikipedia.org/wiki/Graphics_display_resolution */
+    $well_known_resolutions = array(
+        array("CGA",	320,	200),
+        array("QVGA",	320,	240),
+        array("nHD",	640,	360),
+        array("WVGA",	640,	360),
+        array("WVGA",	640,	384),
+        array("VGA",	640,	480),
+        array("NTSC",	720,	480),
+        array("WVGA",	768,	480),
+        array("PAL",	768,	576),
+        array("WVGA",	800,	450),
+        array("WVGA",	800,	480),
+        array("SVGA",	800,	600),
+        array("WVGA",	848,	480),
+        array("WVGA",	852,	480),
+        array("WVGA",	853,	480),
+        array("FWVGA",	854,	480),
+        array("qHD",	960,	540),
+        array("DVGA",	960,	640),
+        array("WSVGA",	1024,	576),
+        array("WSVGA",	1024,	600),
+        array("XGA",	1024,	768),
+        array("WXGA",	1152,	768),
+        array("XGA+",	1152,	864),
+        array("HD",	1280,	720),
+        array("WXGA",	1280,	720),
+        array("WXGA",	1280,	768),
+        array("WXGA",	1280,	800),
+        array("SXGA",	1280,	1024),
+        array("WXGA",	1344,	768),
+        array("WXGA",	1360,	768),
+        array("WXGA",	1366,	768),
+        array("SXGA+",	1400,	1050),
+        array("WXGA+",	1440,	900),
+        array("HD+",	1600,	900),
+        array("UXGA",	1600,	1200),
+        array("WSXGA+",	1680,	1050),
+        array("FHD",	1920,	1080),
+        array("WUXGA",	1920,	1200),
+        array("2K",	2048,	1080),
+        array("QWXGA",	2048,	1152),
+        array("QXGA",	2048,	1536),
+        array("QHD",	2560,	1440),
+        array("QSXGA",	2560,	2048),
+        array("WQXGA",	2560,	1600),
+        array("QHD+",	3200,	1800),
+        array("XQSXGA",	3200,	2048),
+        array("QUXGA",	3200,	2400),
+        array("4K UHD",	3840,	2160),
+        array("WQUXGA",	3840,	2400),
+        array("5K",	5120,	2880),
+        array("8K UHD",	7680,	4320),
+        array("16K",	15360,	8640),
+    );
+
+    $w = max($width, $height);
+    $h = min($width, $height);
+    $name = null;
+    $match = null;
+    $best = null;
+
+    foreach ($well_known_resolutions as $v) {
+        if ($w == $v[1] && $h == $v[2]) {
+            $match = $v[0];
+            break;
+        }
+        if ($approx && $w * 1.02 >= $v[1] && $h * 1.02 >= $v[2]) {
+            $best = $approx.$v[0];
+        }
+    }
+
+    if (isset($match))
+        $name = $match;
+    else if (isset($best))
+        $name = $best;
+    else
+        $name = null;
+
+    return $name;
+}

--- a/objects/videoMetadata.php
+++ b/objects/videoMetadata.php
@@ -1,0 +1,194 @@
+<?php
+
+global $global, $config, $videosPaths;
+if (!isset($global['systemRootPath'])) {
+    require_once '../videos/configuration.php';
+}
+require_once $global['systemRootPath'] . 'videos/configuration.php';
+require_once $global['systemRootPath'] . 'objects/video.php';
+require_once $global['systemRootPath'] . 'objects/Object.php';
+if (!class_exists('VideoMetadata')) {
+
+    class VideoMetadata extends ObjectYPT   {
+
+        protected $id, $videos_id, $resolution, $format, $stream_id, $name, $value;
+
+        static function getTableName() {
+            return 'videos_metadata';
+        }
+    
+        static function getSearchFieldsNames() {
+            return array();
+        }
+    
+        function getId() {
+            return $this->id;
+        }
+    
+        function getVideos_id() {
+            return $this->videos_id;
+        }
+    
+        function getResolution() {
+            return $this->resolution;
+        }
+    
+        function getFormat() {
+            return $this->format;
+        }
+    
+        function getStream_id() {
+            return $this->stream_id;
+        }
+    
+        function getName() {
+            return $this->name;
+        }
+    
+        function getValue() {
+            return $this->value;
+        }
+    
+        function setId($id) {
+            $this->id = $id;
+        }
+    
+        function setVideos_id($videos_id) {
+            $this->videos_id = $videos_id;
+        }
+    
+        function setResolution($resolution) {
+            $this->resolution = $resolution;
+        }
+    
+        function setFormat($format) {
+            $this->format = $format;
+        }
+    
+        function setStream_id($stream_id) {
+            $this->stream_id = $stream_id;
+        }
+    
+        function setName($name) {
+            $this->name = $name;
+        }
+    
+        function setValue() {
+            $this->value = $value;
+        }
+    
+        static function importMetadataFromVideo($video_id) {
+            $paths = Video::getVideosPathsFromID($video_id);
+            foreach ($paths as $format => $paths2) {
+                foreach ($paths2 as $resolution => $url) {
+                    error_log(__function__." $video_id $resolution $format");
+                    self::importMetadata($video_id, $resolution, $format);
+                }
+            }
+        }
+
+        static function importMetadata($video_id, $resolution, $format) {
+            $retval = false;
+            self::deleteMetadataFromVideo($video_id, $resolution, $format);
+    
+            $video = new Video("", "", $video_id);
+          
+            $resolution = trim($resolution, "_");
+            $filename = $video->getFilename()."_".$resolution;
+            $ext = ".".$format;
+            $source = Video::getSourceFile($filename, $ext, false);
+            if (empty($source['path']))
+                return $retval;
+    
+            $file = $source['path'];
+            $cmd = "ffprobe -v quiet -print_format flat  -show_streams ".$file; 
+            exec($cmd . " 2>&1", $output, $retval);
+            if ($retval != 0) {
+                error_log("$cmd failed: ". print_r($output, true));
+                return $retval;
+            }
+    
+            foreach ($output as $line) {
+                $fields = explode(".", $line, 4);
+                if ($fields[0] != "streams" || 
+                    $fields[1] != "stream" || 
+                    !is_numeric($fields[2]))
+                    continue;
+                $stream_id = $fields[2];
+                list($name, $value) = explode("=", $fields[3], 2);
+    
+                if (empty($name) || empty($value))
+                    continue;
+    
+                $meta = new VideoMetadata();
+                $meta->videos_id = $video_id;
+                $meta->resolution = $resolution;
+                $meta->format = $format;
+                $meta->stream_id = $stream_id;
+                $meta->name = $name;
+                $meta->value = trim($value, '"');
+        
+                if ($meta->save() !== false)
+		    $retval = true;
+            }
+
+            return $retval;
+        }
+    
+        static function getMetadata($video_id, $resolution, $format, $stream_id, $name) {
+            global $global, $config;
+            $video_id = intval($video_id);
+            if (is_array($name)) {
+                foreach ($name as $k => $v) 
+                    $n[$k] = "'".$v."'";
+                $n = implode(",", $n);
+            } else {
+                $n = "'".$name."'";
+            }
+            $sql = "SELECT name,value FROM videos_metadata WHERE videos_id = '$video_id'  AND resolution = '$resolution' AND format = '$format' AND stream_id='$stream_id' AND name IN ($n)";
+            $res = sqlDAL::readSql($sql, "", array(), true);
+            while ($meta = sqlDAL::fetchAssoc($res)) 
+                $result[$meta['name']] = $meta['value'];
+            sqlDAL::close($res);
+    
+            if (is_array($name)) {
+                foreach ($name as $n)
+                        $output[] = $result[$n];
+            } else {
+                $output = $result[$name];
+            }
+    
+            return $output;
+        }
+    
+        static function deleteMetadataFromVideo($video_id, $resolution, $format) {
+            global $global, $config;
+            $video_id = intval($video_id);
+            $sql = "DELETE FROM " . static::getTableName() . " ";
+            $sql .= " WHERE videos_id = ? AND resolution = ? AND format = ?";
+            $global['lastQuery'] = $sql;
+            return sqlDAL::writeSql($sql, "iss", array($video_id, $resolution, $format));
+            return;
+        }
+    
+        static function getMetadataByType($video_id, $resolution, $format, $type, $name) {
+            for ($stream_id = 0; ; $stream_id++) {
+                $v = self::getMetadata($video_id, $resolution, $format, $stream_id, "codec_type");
+                if (empty($v)) 
+                    break;
+                if ($v == $type)
+                    return self::getMetadata($video_id, $resolution, $format, $stream_id, $name);
+            }
+        
+            return NULL;
+        }
+    
+        static function getVideoMetadata($video_id, $resolution, $format, $name) {
+            return self::getMetadataByType($video_id, $resolution, $format, "video", $name);
+        }
+    
+        static function getAudioMetadata($video_id, $resolution, $format, $name) {
+            return self::getMetadataByType($video_id, $resolution, $format, "audio", $name);
+        }
+    }
+}

--- a/objects/videos.json.php
+++ b/objects/videos.json.php
@@ -5,6 +5,7 @@ if (!isset($global['systemRootPath'])) {
 }
 session_write_close();
 require_once $global['systemRootPath'] . 'objects/video.php';
+require_once $global['systemRootPath'] . 'objects/videoMetadata.php';
 require_once $global['systemRootPath'] . 'objects/functions.php';
 header('Content-Type: application/json');
 $showOnlyLoggedUserVideos = true;
@@ -54,6 +55,16 @@ foreach ($videos as $key => $value) {
         $videos[$key]['videosURL'] = getVideosURLAudio($videos[$key]['filename']);
     } else {
         $videos[$key]['videosURL'] = getVideosURL($videos[$key]['filename']);
+        foreach ($videos[$key]['videosURL'] as $f => $data) {
+            if ($data['type'] != 'video')
+                continue;
+            list($format, $resolution) = explode("_", $f);
+            list($w, $h) = VideoMetadata::getVideoMetadata($videos[$key]["id"], $resolution, $format, array("width", "height"));
+           $videos[$key]['videosURL'][$f]["width"] = $w;
+           $videos[$key]['videosURL'][$f]["height"] = $h;
+           $videos[$key]['videosURL'][$f]["res_name"] = resolution_to_name($w, $h, "~ ");
+           $videos[$key]['videosURL'][$f]["res_color"] = resolution_to_color($w, $h);
+       }
     }
     unset($videos[$key]['password']);
     unset($videos[$key]['recoverPass']);

--- a/updatedb/updateDb.v10.3.sql
+++ b/updatedb/updateDb.v10.3.sql
@@ -1,0 +1,30 @@
+-- add a metadata table to hold all informations obtained from ffprobe
+-- The constrain of videos.id breaks any change at mine, I do not know why,
+-- but this is why it is commented out.
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
+
+CREATE TABLE IF NOT EXISTS `videos_metadata` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `videos_id` INT NOT NULL,
+  `resolution` VARCHAR(12) NOT NULL,
+  `format` VARCHAR(12) NOT NULL,
+  `stream_id` INT NOT NULL,
+  `name` VARCHAR(128) NOT NULL,
+  `value` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE (`videos_id`, `resolution`, `format`, `stream_id`, `name`),
+  INDEX `fk_videos_metadata_videos1_idx` (`videos_id` ASC)
+  -- CONSTRAINT `fk_videos_metadata_videos1`
+  --   FOREIGN KEY (`videos_id`)
+  --   REFERENCES `videos` (`id`)
+  --   ON DELETE CASCADE
+  --   ON UPDATE CASCADE
+) ENGINE = InnoDB;
+
+UPDATE configurations SET  version = '10.3', modified = now() WHERE id = 1;
+
+SET SQL_MODE=@OLD_SQL_MODE;
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;

--- a/view/managerVideos_body.php
+++ b/view/managerVideos_body.php
@@ -19,6 +19,23 @@
     .modal-dialog {
         width: 90%;
     }
+    .video_res {
+        font-size: 75%;
+        color: #888;
+        margin: 0 1em;
+        text-align: right;
+    }
+    .video_res_name {
+       display: inline-block !important;
+       color: white;
+       padding: .2em .6em .3em;
+       font-size: 75%;
+       font-weight: 700;
+       line-height: 1;
+       white-space: nowrap;
+       border-radius: .25em;
+       text-align: right;
+    }
     @media (max-width:767px){
         .modal-dialog {
             width: 100vw;
@@ -1760,8 +1777,21 @@ if (CustomizeUser::canDownloadVideos()) {
                                                                     download += '<a href="' + downloadURL + '" class="btn btn-default btn-xs" target="_blank" ><span class="fa fa-download " aria-hidden="true"></span> MP4</a>';
                                                                     download += '</div>';
                                                                 } else {
+                                                                    res = '';
+                                                                    res_name = '';
+                                                                    if (row.videosURL[k].width && row.videosURL[k].height) {
+                                                                        res = row.videosURL[k].width + 'x' + row.videosURL[k].height;
+                                                                        res = '<span class="video_res">' + res + '</span>';
+                                                                        res_name_style = '';
+                                                                        if (row.videosURL[k].res_color) {
+                                                                            res_name_style = ' style="background-color: ' + row.videosURL[k].res_color + '"';
+                                                                        }
+                                                                        if (row.videosURL[k].res_name) {
+                                                                            res_name = '<span class="video_res_name"' + res_name_style + '>' + row.videosURL[k].res_name + '</span>';
+                                                                        }
+                                                                    }
                                                                     downloadURL = addGetParam(downloadURL, 'title', row.clean_title + '.mp4');
-                                                                    download += '<a href="' + downloadURL + '" class="btn btn-default btn-xs btn-block" target="_blank"  data-placement="left" data-toggle="tooltip" title="<?php echo str_replace("'", "\\'", __("Download File")); ?>" ><span class="fa fa-download " aria-hidden="true"></span> ' + k + '</a>';
+                                                                    download += '<a href="' + downloadURL + '" class="btn btn-default btn-xs btn-block" target="_blank"  data-placement="left" data-toggle="tooltip" title="<?php echo str_replace("'", "\\'", __("Download File")); ?>" ><span class="fa fa-download " aria-hidden="true"></span> ' + k + res + res_name + '</a>';
                                                                 }
 
                                                             }


### PR DESCRIPTION
A new videos_metadata table is created for this purpose, where
we store all informations returned by ffprobe.

The table is populated when encoder uploads the video. A
CLI script install/metadata.php is provided to load the
metadata for all existing videos.

A first usage is to display video resolution on the video download
button.