### PR TITLE
Update nginx.conf

### DIFF
--- a/plugin/Live/install/nginx.conf
+++ b/plugin/Live/install/nginx.conf
@@ -29,12 +29,22 @@ worker_processes  1;
                             #    -c:v libx264 -vf scale=-2:720 -re 30 -g 60 -keyint_min 48 -sc_threshold 0 -bf 3 -b_strategy 2 -b:v 2400k -maxrate 3000k -bufsize 6000k -c:a aac -strict -2 -b:a 128k  -f hls -hls_time 2 -hls_list_size 0 -f flv rtmp://localhost/adaptive/$name_hi;
 
 
-                            #recorder video{
+                            #recorder video {
                             #    record all;
                             #    record_path /var/www/tmp;
                             #    record_notify on;
                             #    record_max_size 2048M; 
                             #    record_suffix -%d-%b-%y-%T.flv;
+                            ###If live-stream is over 30FPS and you want to limit it to 30FPS recording to light the encoding task #record_max_frames 30;
+                            #    record_max_frames 30;
+                            #}
+                    
+                            ### Record Audio Separately ( For podcast )
+                            #recorder audio {
+                            #    record audio;
+                            #    record_path /var/www/tmp;
+                            #    record_max_size 1024M;
+                            #    record_suffix -%d-%b-%y-%T.mp3;
                             #}
                     }
 


### PR DESCRIPTION
`mp3` is not what rtmp-nginx page recommends , but mp3 does work as expected.
If issues happens , then the default option should be `.audio.flv` . MP3 is just easier to identify , in case of implementation on plugin SendStreamToRecorder.

If I play a bit around it the plugin should already work, but would be better to have an option to enable or disable the Video/Audio encoding.

Also the encoding gonna happen in real time. Mp3 to mp3 ( `-c copy` with `-movflags +faststart` )