### PR TITLE
Add PHP Linter.

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: validate
+name: Validate/Lint
 
 on: [push, pull_request]
 
@@ -23,3 +23,28 @@ jobs:
 
   - name: Validate composer.json and composer.lock
     run: composer validate
+
+  - name: Lint
+    run: |
+     lintPaths=()
+     lintPaths+=("${GITHUB_WORKSPACE}/admin")
+     lintPaths+=("${GITHUB_WORKSPACE}/feed")
+     lintPaths+=("${GITHUB_WORKSPACE}/install")
+     lintPaths+=("${GITHUB_WORKSPACE}/locale")
+     lintPaths+=("${GITHUB_WORKSPACE}/view")
+     lintPaths+=("${GITHUB_WORKSPACE}/index.php")
+     for lintPath in "${lintPaths[@]}"
+     do
+     for file in `find "$lintPath"`
+     do
+     EXTENSION="${file##*.}"
+     if [ "$EXTENSION" == "php" ] || [ "$EXTENSION" == "phtml" ]
+     then
+     RESULTS=`php -l "$file"`
+     if [ "$RESULTS" != "No syntax errors detected in $file" ]
+     then
+     echo $RESULTS
+     fi
+     fi
+     done
+     done


### PR DESCRIPTION
Adds some basic linting to the workflow. This should help a little for being able to quickly identify whenever future commits introduce syntax errors in any of the PHP files checked, by changing the green "✔️" seen against commits in the commit history into a red "❌" for any future commits introducing such syntax errors.

Currently just checks `feed`, `install`, `locale`, `view`, and `index.php`. Because those directories (and one file) don't total too many files, checking just those shouldn't take too much time (based on the commit which this PR includes, approximately ~28 seconds).

But, because the `objects` and `plugin` directories contain a huge number of files, checking them at each commit would take a much longer amount of time (too much time, IMO), so better to just skip those for now, and maybe check them manually/offline whenever there are any concerns about them.

I've avoided using any standards checkers or style checkers for the workflow, because AVideo doesn't adopt any strict code-style guidelines or standards AFAICT, so introducing such standards checkers or style checkers could potentially complicate the process of contributing to AVideo or inadvertently create unwanted, additional work for the maintainers. Instead, the linting introduced by this PR, relies just on PHP's own internal linter, which only checks basic syntax, ensuring that PHP can read the files, etc, and just uses basic bash scripting to identifying PHP files from other kinds of files. 