### PR TITLE
Extend lint paths to include objects.

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,6 +31,7 @@ jobs:
      lintPaths+=("${GITHUB_WORKSPACE}/feed")
      lintPaths+=("${GITHUB_WORKSPACE}/install")
      lintPaths+=("${GITHUB_WORKSPACE}/locale")
+     lintPaths+=("${GITHUB_WORKSPACE}/objects")
      lintPaths+=("${GITHUB_WORKSPACE}/view")
      lintPaths+=("${GITHUB_WORKSPACE}/index.php")
      for lintPath in "${lintPaths[@]}"


### PR DESCRIPTION
Now that all the Composer dependencies' files (more than 34,700+ files currently) have been moved out from the objects directory, into their own vendor directory, the number of files within the objects directory is a little more manageable (129 files total at this time).

This means that, unlike before, it should now be possible to lint that directory without incurring an unreasonable performance hit to our actions and workflows.

This PR extends the lint paths to include the objects directory accordingly.