### PR TITLE
change > to < in already send mail if statement

### DIFF
--- a/objects/user.php
+++ b/objects/user.php
@@ -2045,7 +2045,7 @@ if (typeof gtag !== \"function\") {
     public static function sendVerificationLink($users_id) {
         global $global, $advancedCustomUser;
         //Only send the verification email each 30 minutes
-        if (!empty($_SESSION["sendVerificationLink"][$users_id]) && time() - $_SESSION["sendVerificationLink"][$users_id] > 1800) {
+        if (!empty($_SESSION["sendVerificationLink"][$users_id]) && time() - $_SESSION["sendVerificationLink"][$users_id] < 1800) {
             _error_log("sendVerificationLink: Email already sent, we will wait 30 min  {$users_id}");
             return true;
         }


### PR DESCRIPTION
Found a issue that sending two verification mail when user sign or when user try to connect with unverified mail and the server send new verification mail.

It already have a if statement to avoid sending multiple mail for 30 minute but the if statement is incorect.
We need to stop (return true) in the if statement if the difference between actual time and last send mail is less than 1800 and not more than.

When user try to loggin, the loginFromRequest() of objects/user.php execute "$user->login()" twice cause of "if ($response !== self::USER_LOGGED) {" statement at the same second.

That the difference between two call are less than 1800 second and we need to stop the execution of sendVerificationLink function.