### PR TITLE
Remove obsolete README.md data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,16 +204,6 @@ In production you should remove the phpmyadmin image by setting `ENABLE_PHPMYADM
 
 Also we're working on a prebuild image. So you can use the image from [Docker hub](https://hub.docker.com/r/trickert76/avideo-platform/tags).
 
-# Roadmap
-
-## Version 8.9
-
-## Version 8.10
-
-## Version 8.11
-
-## git clone
-
 After a git clone command run this
 
 composer update --prefer-dist --ignore-platform-reqs


### PR DESCRIPTION
Given that the current latest AVideo tag is already at 11.6, it doesn't make sense to include empty roadmap entries for 8.x versions.