### PR TITLE
Files with UPPER case extensions not listing in bulk upload

### DIFF
--- a/objects/listFiles.json.php
+++ b/objects/listFiles.json.php
@@ -17,7 +17,10 @@ if (!empty($_POST['path'])) {
     }
 
     if (file_exists($path)) {
-        $filesStr = "{*." . implode(",*.", $global['allowed']) . "}";
+        $extn = implode(",*.", $global['allowed']);
+        $extnLower = strtolower($extn);
+        $extnUpper = strtoupper($extn);
+        $filesStr = "{*." . $extn . ",*" . $extnLower . ",*" . $extnUpper . "}";
 
         //echo $files;
         $video_array = glob($path . $filesStr, GLOB_BRACE);


### PR DESCRIPTION
This fix will take the same allowed list to be considered in it's current original case (can be mixed), lower case format and also upper case format. Since it is also possible that some formats are mixed case (Ex: Mov instead of MOV) it is better to take all three cases (though may have duplicates in $fileStr, does not hurt.).