### PR TITLE
Fixed captcha text css selector

### DIFF
--- a/plugin/YPTWallet/view/transferFunds.php
+++ b/plugin/YPTWallet/view/transferFunds.php
@@ -121,7 +121,7 @@ $_page = new Page(array('Transfer Funds'));
                             data: {
                                 "value": $('#value').val(),
                                 "users_id": $('#users_id').val(),
-                                "captcha": $('#captchaText').val()
+                                "captcha": <?php echo $capcha['captchaText']; ?>
                             },
                             type: 'post',
                             success: function(response) {


### PR DESCRIPTION
YPTWallet transfer funds from your account to another user account captcha text not submitted for non-admins

https://demo.avideo.com/plugin/YPTWallet/view/transferFunds.php

![image](https://github.com/WWBN/AVideo/assets/3822668/a7b070a8-10b9-4285-90e0-00bf9cbd6a42)

due to wrong css selector

https://github.com/WWBN/AVideo/blob/5fd3017d6aa0b2decd2863ffa66615a901b37e87/plugin/YPTWallet/view/transferFunds.php#L124

which should be the same as

https://github.com/WWBN/AVideo/blob/5fd3017d6aa0b2decd2863ffa66615a901b37e87/plugin/CustomizeUser/actionButton.php#L127