### PR TITLE
Limit some workflows to the parent repository

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -7,6 +7,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    if: github.repository == 'WWBN/AVideo'
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'WWBN/AVideo'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Limits some workflows to the parent repository, as they aren't needed at forks (don't need forks to be trying to generate docker images).