### PR TITLE
Add Canadian English support + update Australian English.

### DIFF
--- a/locale/en_AU.php
+++ b/locale/en_AU.php
@@ -20,4 +20,3 @@ $t['Organize'] = 'Organise';
 $t['The Permissions Plugin is not installed. Please install it if you want to customize the permissions.'] = 'The Permissions Plugin is not installed. Please install it if you want to customise the permissions.';
 $t['Truly customize your AVideo and create a more professional video sharing site experience for your visitors by removing or replacing the footer, about page and Meta Description with your own.'] = 'Truly customise your AVideo and create a more professional video sharing site experience for your visitors by removing or replacing the footer, about page and Meta Description with your own.';
 $t['You can not manager plugin customize'] = 'You can not manager plugin customise';
-$t['Your maximum file size is:'] = 'Your maximum file size is:';

--- a/locale/en_CA.php
+++ b/locale/en_CA.php
@@ -1,0 +1,11 @@
+<?php
+// Because we're including the US English file here as a default to fall back
+// on, we should only include translations in this file here where they differ
+// from their US counterparts.
+include __DIR__ . '/en_US.php';
+
+$t['Canceled'] = 'Cancelled';
+$t['Color Legend'] = 'Colour Legend';
+$t['Colors'] = 'Colours';
+$t['Customize Your site colors'] = 'Customize Your site colours';
+$t['In authorized credentials allow the following URIs redirection'] = 'In authorized credentials allow the following URIs redirection';


### PR DESCRIPTION
Canadian English has similarities to American English, British English, and Australian English, but *is* just *slightly* different from all of them, so there may be value in providing support for it.

For example:
American English | British English and Australian English | Canadian English
---|---|---
Color | Colour | Colour
Colorize | Colourise | Colourize
Authorization | Authorisation | Authorization
Honorable | Honourable | Honourable

This pull request adds a locale file for it.