### PR TITLE
Portable timezone read

### DIFF
--- a/objects/functions.php
+++ b/objects/functions.php
@@ -5851,18 +5851,7 @@ function getSystemTimezone()
         return $_getSystemTimezoneName;
     }
 
-    if (isWindowsServer()) {
-        $cmd = 'tzutil /g';
-        $_getDatabaseTimezoneName = trim(preg_replace('/[^a-z0-9_ \/-]+/si', '', shell_exec($cmd)));
-    } else if (file_exists('/etc/timezone')) { /* Linux */
-        $_getDatabaseTimezoneName = trim(preg_replace('/[^a-z0-9_ \/-]+/si', '', file_get_contents('/etc/timezone')));
-    } else if (file_exists('/etc/localtime')) { /* BSD */
-        $_getDatabaseTimezoneName = preg_replace('/^.*zoneinfo\//', '', readlink('/etc/localtime'));
-    } else {
-        $_getDatabaseTimezoneName = '';
-    }
-
-    $_getDatabaseTimezoneName = fixTimezone($_getDatabaseTimezoneName);
+    $_getDatabaseTimezoneName = fixTimezone(date('e'));
 
     return $_getDatabaseTimezoneName;
 }

--- a/objects/functions.php
+++ b/objects/functions.php
@@ -5853,11 +5853,14 @@ function getSystemTimezone()
 
     if (isWindowsServer()) {
         $cmd = 'tzutil /g';
+        $_getDatabaseTimezoneName = trim(preg_replace('/[^a-z0-9_ \/-]+/si', '', shell_exec($cmd)));
+    } else if (file_exists('/etc/timezone')) { /* Linux */
+        $_getDatabaseTimezoneName = trim(preg_replace('/[^a-z0-9_ \/-]+/si', '', file_get_contents('/etc/timezone')));
+    } else if (file_exists('/etc/localtime')) { /* BSD */
+        $_getDatabaseTimezoneName = preg_replace('/^.*zoneinfo\//', '', readlink('/etc/localtime'));
     } else {
-        $cmd = 'cat /etc/timezone';
+        $_getDatabaseTimezoneName = '';
     }
-
-    $_getDatabaseTimezoneName = trim(preg_replace('/[^a-z0-9_ \/-]+/si', '', shell_exec($cmd)));
 
     $_getDatabaseTimezoneName = fixTimezone($_getDatabaseTimezoneName);
 


### PR DESCRIPTION
Also improve Linux way of reading /etc/timezone, using file_get_contents() instead of forking a shell.