### PR TITLE
Add installation tests for required PHP modules

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -49,7 +49,7 @@ require_once '../locale/function.php';
                                     ?>
                                     <div class="alert alert-success">
                                         <i class="fa-regular fa-square-check"></i>
-                                        <strong><?php echo $_SERVER['SERVER_SOFTWARE']; ?> is Present</strong>
+                                        <strong><?php echo $_SERVER['SERVER_SOFTWARE']; ?> is present</strong>
                                     </div>
                                     <?php
                                 } else {
@@ -73,6 +73,74 @@ require_once '../locale/function.php';
                                     <div class="alert alert-warning">
                                         <i class="fa-solid fa-circle-exclamation"></i>
                                         <strong>Your PHP version is <?php echo PHP_VERSION; ?>. PHP 7.3 or newer is required.</strong>
+                                    </div>
+                                    <?php
+                                } ?>
+
+                                <?php
+                                if (class_exists('mysqli')) {
+                                    ?>
+                                    <div class="alert alert-success">
+                                        <i class="fa-regular fa-square-check"></i>
+                                        <strong>php-mysqli module is present.</strong>
+                                    </div>
+                                    <?php
+                                } else {
+                                    ?>
+                                    <div class="alert alert-warning">
+                                        <i class="fa-solid fa-circle-exclamation"></i>
+                                        <strong>php-mysqli module is required.</strong>
+                                    </div>
+                                    <?php
+                                } ?>
+
+                                <?php
+                                if (function_exists('mb_strlen')) {
+                                    ?>
+                                    <div class="alert alert-success">
+                                        <i class="fa-regular fa-square-check"></i>
+                                        <strong>php-mbstring module is present.</strong>
+                                    </div>
+                                    <?php
+                                } else {
+                                    ?>
+                                    <div class="alert alert-warning">
+                                        <i class="fa-solid fa-circle-exclamation"></i>
+                                        <strong>php-mbstring module is required.</strong>
+                                    </div>
+                                    <?php
+                                } ?>
+
+                                <?php
+                                if (function_exists('imagecreate')) {
+                                    ?>
+                                    <div class="alert alert-success">
+                                        <i class="fa-regular fa-square-check"></i>
+                                        <strong>php-gd module is present.</strong>
+                                    </div>
+                                    <?php
+                                } else {
+                                    ?>
+                                    <div class="alert alert-warning">
+                                        <i class="fa-solid fa-circle-exclamation"></i>
+                                        <strong>php-gd module is required.</strong>
+                                    </div>
+                                    <?php
+                                } ?>
+
+                                <?php
+                                if (function_exists('ob_gzhandler')) {
+                                    ?>
+                                    <div class="alert alert-success">
+                                        <i class="fa-regular fa-square-check"></i>
+                                        <strong>php-zlib module is present.</strong>
+                                    </div>
+                                    <?php
+                                } else {
+                                    ?>
+                                    <div class="alert alert-warning">
+                                        <i class="fa-solid fa-circle-exclamation"></i>
+                                        <strong>php-zlib module is required.</strong>
                                     </div>
                                     <?php
                                 } ?>

--- a/install/index.php
+++ b/install/index.php
@@ -18,7 +18,10 @@ require_once '../locale/function.php';
             .bootstrap-select{
                 width: 100% !important;
             }
-
+            .alert{
+                padding: 2px 25px;
+                margin-bottom: 10px;
+            }
         </style>
     </head>
 
@@ -78,18 +81,52 @@ require_once '../locale/function.php';
                                 } ?>
 
                                 <?php
-                                if (class_exists('mysqli')) {
+                                if (function_exists('curl_init')) {
                                     ?>
                                     <div class="alert alert-success">
                                         <i class="fa-regular fa-square-check"></i>
-                                        <strong>php-mysqli module is present.</strong>
+                                        <strong>php-curl module is present.</strong>
                                     </div>
                                     <?php
                                 } else {
                                     ?>
                                     <div class="alert alert-warning">
                                         <i class="fa-solid fa-circle-exclamation"></i>
-                                        <strong>php-mysqli module is required.</strong>
+                                        <strong>php-curl module is required.</strong>
+                                    </div>
+                                    <?php
+                                } ?>
+
+                                <?php
+                                if (function_exists('imagecreate')) {
+                                    ?>
+                                    <div class="alert alert-success">
+                                        <i class="fa-regular fa-square-check"></i>
+                                        <strong>php-gd module is present.</strong>
+                                    </div>
+                                    <?php
+                                } else {
+                                    ?>
+                                    <div class="alert alert-warning">
+                                        <i class="fa-solid fa-circle-exclamation"></i>
+                                        <strong>php-gd module is required.</strong>
+                                    </div>
+                                    <?php
+                                } ?>
+
+                                <?php
+                                if (function_exists('json_encode')) {
+                                    ?>
+                                    <div class="alert alert-success">
+                                        <i class="fa-regular fa-square-check"></i>
+                                        <strong>php-json module is present.</strong>
+                                    </div>
+                                    <?php
+                                } else {
+                                    ?>
+                                    <div class="alert alert-warning">
+                                        <i class="fa-solid fa-circle-exclamation"></i>
+                                        <strong>php-json module is required.</strong>
                                     </div>
                                     <?php
                                 } ?>
@@ -112,18 +149,35 @@ require_once '../locale/function.php';
                                 } ?>
 
                                 <?php
-                                if (function_exists('imagecreate')) {
+                                if (class_exists('mysqli')) {
                                     ?>
                                     <div class="alert alert-success">
                                         <i class="fa-regular fa-square-check"></i>
-                                        <strong>php-gd module is present.</strong>
+                                        <strong>php-mysqli module is present.</strong>
                                     </div>
                                     <?php
                                 } else {
                                     ?>
                                     <div class="alert alert-warning">
                                         <i class="fa-solid fa-circle-exclamation"></i>
-                                        <strong>php-gd module is required.</strong>
+                                        <strong>php-mysqli module is required.</strong>
+                                    </div>
+                                    <?php
+                                } ?>
+
+                                <?php
+                                if (class_exists('ZipArchive')) {
+                                    ?>
+                                    <div class="alert alert-success">
+                                        <i class="fa-regular fa-square-check"></i>
+                                        <strong>php-zip module is present.</strong>
+                                    </div>
+                                    <?php
+                                } else {
+                                    ?>
+                                    <div class="alert alert-warning">
+                                        <i class="fa-solid fa-circle-exclamation"></i>
+                                        <strong>php-zip module is required.</strong>
                                     </div>
                                     <?php
                                 } ?>


### PR DESCRIPTION
As shown in issue https://github.com/WWBN/AVideo/issues/9892 missing PHP module can cause breakage without error being reported. It seems desirable to check for their presence at installation time, which is what is change does.