### PR TITLE
Avoid uniqid() for performance sake

### DIFF
--- a/CreatePlugin/create.json.php
+++ b/CreatePlugin/create.json.php
@@ -185,7 +185,7 @@ try {
     $pluginTemplate = file_get_contents("templates/plugin.php");
     $pluginData = str_replace(
         ['{pluginName}', '{includeTables}', '{tablename}', '{uid}'],
-        [$pluginName, implode(PHP_EOL, $includeTables), $pluginName, uniqid()],
+        [$pluginName, implode(PHP_EOL, $includeTables), $pluginName, _uniqid()],
         $pluginTemplate
     );
     file_put_contents($pluginFile, $pluginData);

--- a/admin/functions.php
+++ b/admin/functions.php
@@ -65,7 +65,7 @@ function jsonToFormElements($json, $filter = [])
             $elements[] = "<tr><td>{$label} </td><td>{$input}{$help}</td></tr>";
         } elseif (is_bool($valueJson)) {
             //var_dump($keyJson, $valueJson, '---<br>');
-            $id = uniqid();
+            $id = _uniqid();
             $input = '<div class="material-switch">
                                 <input data-toggle="toggle" type="checkbox" id="' . $keyJson . $id . '" name="' . $keyJson . '" value="1" ' . ($valueJson ? "checked" : "") . ' >
                                 <label for="' . $keyJson . $id . '" class="label-primary"></label>
@@ -86,7 +86,7 @@ function getPluginSwitch($pluginName)
     } else {
         $plugin = AVideoPlugin::loadPluginIfEnabled($pluginName);
         $pluginForced = AVideoPlugin::loadPlugin($pluginName);
-        $id = uniqid();
+        $id = _uniqid();
         $uuid = $pluginForced->getUUID();
         $input = '<div class="material-switch">
                                 <input class="pluginSwitch" data-toggle="toggle" type="checkbox" id="' . $id . '" uuid="' . $uuid . '" name="' . $pluginName . '" value="1" ' . (!empty($plugin) ? "checked" : "") . ' >

--- a/admin/index.php
+++ b/admin/index.php
@@ -247,7 +247,7 @@ if (!empty($includeHead) && file_exists($includeHead)) {
                     $panel = 'panel-primary';
                 }
                 foreach ($itens as $key => $value) {
-                    $uid = uniqid();
+                    $uid = _uniqid();
                     $href = 'data-toggle="collapse" data-parent="#accordion" href="#collapse' . $uid . '"';
                     if (!empty($value->href)) {
                         $href = 'href="' . $global['webSiteRootURL'] . 'admin/?page=' . $value->href . '"';

--- a/install/checkConfiguration.php
+++ b/install/checkConfiguration.php
@@ -183,7 +183,7 @@ error_log("Installation: ".__LINE__);
 $mysqli->close();
 
 if (empty($_POST['salt'])) {
-    $_POST['salt'] = uniqid();
+    $_POST['salt'] = _uniqid();
 }
 $content = "<?php
 \$global['configurationVersion'] = 3.1;

--- a/install/populateForTest.php
+++ b/install/populateForTest.php
@@ -119,7 +119,7 @@ $newVideosIds = array();
 for ($i = 0; $i < $totalVideos; $i++) {
     $date = date('Y/m/d H:i:s');
     $title = "[$i] Auto {$date}";
-    $filename = "testvideo{$i}_" . uniqid();
+    $filename = "testvideo{$i}_" . _uniqid();
     $video = new Video($title, $filename);
 
     $video->setDuration("00:00:45");

--- a/objects/ICS.php
+++ b/objects/ICS.php
@@ -119,7 +119,7 @@ class ICS {
 
     // Set some default values
     $props['DTSTAMP'] = $this->format_timestamp('now');
-    $props['UID'] = uniqid();
+    $props['UID'] = _uniqid();
 
     // Append properties
     foreach ($props as $k => $v) {

--- a/objects/Object.php
+++ b/objects/Object.php
@@ -856,7 +856,7 @@ abstract class ObjectYPT implements ObjectInterface
         //_error_log('deleteALLCache: '.json_encode(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)));
         $tmpDir = self::getCacheDir('', false);
 
-        $newtmpDir = rtrim($tmpDir, DIRECTORY_SEPARATOR) . uniqid();
+        $newtmpDir = rtrim($tmpDir, DIRECTORY_SEPARATOR) . _uniqid();
         _error_log("deleteALLCache rename($tmpDir, $newtmpDir) ");
         @rename($tmpDir, $newtmpDir);
         if (is_dir($tmpDir)) {

--- a/objects/category.php
+++ b/objects/category.php
@@ -157,7 +157,7 @@ class Category
         // check if clean name exists
         $exists = $this->getCategoryByName($this->clean_name);
         if (!empty($exists) && $exists['id'] !== $this->id) {
-            $this->clean_name .= uniqid();
+            $this->clean_name .= _uniqid();
         }
 
         $this->nextVideoOrder = intval($this->nextVideoOrder);

--- a/objects/functionCroppie.php
+++ b/objects/functionCroppie.php
@@ -41,7 +41,7 @@ function getCroppieElement(
     }
     $boundaryWidth = $viewportWidth + $boundary;
     $boundaryHeight = $viewportHeight + $boundary;
-    $uid = uniqid();
+    $uid = _uniqid();
 
     $varsArray = [
         'buttonTitle' => $buttonTitle,

--- a/objects/functionInfiniteScroll.php
+++ b/objects/functionInfiniteScroll.php
@@ -59,7 +59,7 @@ function getPagination($total, $link = "", $maxVisible = 10, $infinityScrollGetF
 
     $isInfiniteScroll = !empty($infinityScrollGetFromSelector) && !empty($infinityScrollAppendIntoSelector);
 
-    $uid = uniqid();
+    $uid = _uniqid();
 
     if ($total < $maxVisible) {
         $maxVisible = $total;

--- a/objects/functiongetShareMenu.php
+++ b/objects/functiongetShareMenu.php
@@ -56,7 +56,7 @@ $replace = [$permaLink, $img, $title, $embedURL, $videoLengthInSeconds];
                     //$title = urlencode($title);
                     include $global['systemRootPath'] . 'view/include/social.php';
                     $type = 'animate__flipInX';
-                    $loaderSequenceName = uniqid();
+                    $loaderSequenceName = _uniqid();
                     ?>
                 </div>
                 <div class="tab-pane" id="tabEmbed">
@@ -87,7 +87,7 @@ $replace = [$permaLink, $img, $title, $embedURL, $videoLengthInSeconds];
                 </div>
                 <?php
                 if (empty($advancedCustom->disableEmailSharing)) {
-                    $loaderSequenceName = uniqid();
+                    $loaderSequenceName = _uniqid();
                     ?>
                     <div class="tab-pane" id="tabEmail">
                         <?php if (!User::isLogged()) { ?>
@@ -167,7 +167,7 @@ $replace = [$permaLink, $img, $title, $embedURL, $videoLengthInSeconds];
                     <?php
                 }
                 if (!empty($permaLink) && $permaLink !== $URLFriendly) {
-                    $loaderSequenceName = uniqid();
+                    $loaderSequenceName = _uniqid();
                     ?>
                     <div class="tab-pane" id="tabPermaLink">
                         <div class="form-group <?php echo getCSSAnimationClassAndStyle($type, $loaderSequenceName); ?>">

--- a/objects/functions.php
+++ b/objects/functions.php
@@ -4202,7 +4202,7 @@ function getInputCopyToClipboard($id, $value, $attributes = 'class="form-control
 
 function getButtontCopyToClipboard($elemToCopyId, $attributes = 'class="btn btn-default btn-sm btn-xs pull-right"', $label = "Copy to Clipboard")
 {
-    $id = "getButtontCopyToClipboard" . uniqid();
+    $id = "getButtontCopyToClipboard" . _uniqid();
 ?>
     <button id="<?php echo $id; ?>" <?php echo $attributes; ?> data-toggle="tooltip" data-placement="left" title="<?php echo __($label); ?>"><i class="fas fa-clipboard"></i> <?php echo __($label); ?></button>
     <script>
@@ -4355,7 +4355,7 @@ function getCaptcha($uid = "", $forceCaptcha = false)
 {
     global $global;
     if (empty($uid)) {
-        $uid = "capcha_" . uniqid();
+        $uid = "capcha_" . _uniqid();
     }
     $contents = getIncludeFileContent($global['systemRootPath'] . 'objects/functiongetCaptcha.php', ['uid' => $uid, 'forceCaptcha' => $forceCaptcha]);
 
@@ -4737,13 +4737,13 @@ function getTimerFromDates($startTime, $endTime = 0)
         $endTime = time();
     }
     $timer = abs($endTime - $startTime);
-    $uid = uniqid();
+    $uid = _uniqid();
     return "<span id='{$uid}'></span><script>$(document).ready(function () {startTimer({$timer}, '#{$uid}', '');})</script>";
 }
 
 function getServerClock()
 {
-    $id = uniqid();
+    $id = _uniqid();
     $today = getdate();
     $html = '<span id="' . $id . '">00:00:00</span>';
     $html .= "<script type=\"text/javascript\">
@@ -4850,7 +4850,7 @@ function getSocialModal($videos_id, $url = "", $title = "")
 {
     global $global;
     $video['id'] = $videos_id;
-    $sharingUid = uniqid();
+    $sharingUid = _uniqid();
     $filePath = $global['systemRootPath'] . 'objects/functionGetSocialModal.php';
     $contents = getIncludeFileContent(
         $filePath,
@@ -6703,7 +6703,7 @@ function getHamburgerButton($id = '', $type = 0, $parameters = 'class="btn btn-d
         $type = rand(1, 8);
     }
     if (empty($id)) {
-        $id = uniqid();
+        $id = _uniqid();
     }
     $filePath = $global['systemRootPath'] . 'objects/functionGetHamburgerButton.php';
     return getIncludeFileContent($filePath, ['type' => $type, 'id' => $id, 'parameters' => $parameters, 'startActive' => $startActive, 'invert' => $invert]);
@@ -7064,7 +7064,7 @@ function getRandomCode()
     $char1 = $characters[rand(0, $max)];
     $char2 = $characters[rand(0, $max)];
     $char3 = $characters[rand(0, $max)];
-    $uniqueId = uniqid();
+    $uniqueId = _uniqid();
     $uniquePart1 = str_pad(base_convert(substr($uniqueId, -5), 16, 36), 4, $char1, STR_PAD_LEFT);
     $uniquePart2 = str_pad(base_convert(substr($uniqueId, 4, 4), 16, 36), 4, $char2, STR_PAD_LEFT);
     $uniquePart3 = str_pad(base_convert(substr($uniqueId, 0, 4), 16, 36), 4, $char3, STR_PAD_LEFT);
@@ -7107,7 +7107,7 @@ function generateHorizontalFlickity($items)
         <link href="<?php echo getURL('node_modules/flickity/dist/flickity.min.css'); ?>" rel="stylesheet" type="text/css" />
     <?php
     }
-    $carouselClass = 'carousel_' . uniqid();
+    $carouselClass = 'carousel_' . _uniqid();
     ?>
     <div id="<?php echo $carouselClass; ?>" class=" HorizontalFlickity" style="visibility: hidden;">
         <?php

--- a/objects/functionsFile.php
+++ b/objects/functionsFile.php
@@ -740,7 +740,7 @@ function wgetIsLocked($url)
 function isWritable($dir)
 {
     $dir = rtrim($dir, '/') . '/';
-    $file = $dir . uniqid();
+    $file = $dir . _uniqid();
     $result = false;
     $time = time();
     if (@file_put_contents($file, $time)) {
@@ -759,7 +759,7 @@ function _isWritable($dir)
     if (!isWritable($dir)) {
         return false;
     }
-    $tmpFile = "{$dir}" . uniqid();
+    $tmpFile = "{$dir}" . _uniqid();
     $bytes = @file_put_contents($tmpFile, time());
     @unlink($tmpFile);
     return !empty($bytes);
@@ -805,7 +805,7 @@ function getTmpDir($subdir = "")
 
 function getTmpFile()
 {
-    return getTmpDir("tmpFiles") . uniqid();
+    return getTmpDir("tmpFiles") . _uniqid();
 }
 
 function _file_put_contents($filename, $data, $flags = 0, $context = null)

--- a/objects/functionsGetTinyMCE.php
+++ b/objects/functionsGetTinyMCE.php
@@ -1,6 +1,6 @@
 <?php
 global $tinyMCELibs;
-$tinyMCEuid = uniqid();
+$tinyMCEuid = _uniqid();
 
 // Basic configurations
 $basicValidElements = 'a[role|href|target|data-toggle|data-parent|data-dismiss|aria-expanded|aria-controls|class|title],' .

--- a/objects/functionsImages.php
+++ b/objects/functionsImages.php
@@ -276,7 +276,7 @@ function convertImageToOG($source, $destination)
         $sizes = getimagesize($source);
         if ($sizes[0] < $w || $sizes[1] < $h) {
             $tmpDir = getTmpDir();
-            $fileConverted = $tmpDir . "_jpg_" . uniqid() . ".jpg";
+            $fileConverted = $tmpDir . "_jpg_" . _uniqid() . ".jpg";
             convertImage($source, $fileConverted, 100);
             im_resize($fileConverted, $destination, $w, $h, 100);            
             //_error_log("convertImageToOG ($destination) unlink line=".__LINE__);
@@ -324,7 +324,7 @@ function convertImageIfNotExists($source, $destination, $width, $height, $scaleU
         //_error_log("convertImageIfNotExists($source, $destination, $width, $height)");
         try {
             $tmpDir = getTmpDir();
-            $fileConverted = $tmpDir . "_jpg_" . uniqid() . ".jpg";
+            $fileConverted = $tmpDir . "_jpg_" . _uniqid() . ".jpg";
             convertImage($source, $fileConverted, 100);
             if (file_exists($fileConverted)) {
                 if ($scaleUp) {
@@ -354,7 +354,7 @@ function convertImageIfNotExists($source, $destination, $width, $height, $scaleU
 
 function getVideoImagewithHoverAnimation($relativePath, $relativePathHoverAnimation = '', $title = '', $preloadImage = false, $doNotUseAnimatedGif = false)
 {
-    $id = uniqid();
+    $id = _uniqid();
     //getImageTagIfExists($relativePath, $title = '', $id = '', $style = '', $class = 'img img-responsive', $lazyLoad = false, $preloadImage=false)
     $img = getImageTagIfExists($relativePath, $title, "thumbsJPG{$id}", '', 'thumbsJPG img img-responsive', false, $preloadImage) . PHP_EOL;
     if (empty($doNotUseAnimatedGif) && !empty($relativePathHoverAnimation) && empty($_REQUEST['noImgGif'])) {

--- a/objects/functionsMail.php
+++ b/objects/functionsMail.php
@@ -184,7 +184,7 @@ function sendSiteEmailAsync($to, $subject, $message)
     $to = array_unique($to);
     $content = ['to' => $to, 'subject' => $subject, 'message' => $message];
     //$tmpFile = getTmpFile();
-    $tmpFile = "{$global['systemRootPath']}videos/emails_" . uniqid() . '.log';
+    $tmpFile = "{$global['systemRootPath']}videos/emails_" . _uniqid() . '.log';
     $bytes = file_put_contents($tmpFile, _json_encode($content));
     //outputAndContinueInBackground();
     $command = "php {$global['systemRootPath']}objects/sendSiteEmailAsync.php '$tmpFile' && rm '$tmpFile'";

--- a/objects/functionsStandAlone.php
+++ b/objects/functionsStandAlone.php
@@ -60,7 +60,7 @@ function loadStandaloneConfiguration()
             $content .= "\$doNotIncludeConfig = 1;" . PHP_EOL;
             $content .= "\$doNotConnectDatabaseIncludeConfig = 1;" . PHP_EOL;
             $content .= "\$doNotStartSessionIncludeConfig = 1;" . PHP_EOL;
-            $content .= "\$global['salt'] = '" . uniqid() . "';" . PHP_EOL;
+            $content .= "\$global['salt'] = '" . _uniqid() . "';" . PHP_EOL;
             $content .= "\$global['webSiteRootURL'] = '{$global['webSiteRootURL']}';" . PHP_EOL;
             $content .= "\$global['systemRootPath'] = '{$global['systemRootPath']}';" . PHP_EOL;
             $content .= "require_once \$global['systemRootPath'] . 'objects/include_config.php';" . PHP_EOL;

--- a/objects/sites.php
+++ b/objects/sites.php
@@ -64,7 +64,7 @@ class Sites extends ObjectYPT
     public function save()
     {
         if (empty($this->getSecret())) {
-            $this->setSecret(md5(uniqid()));
+            $this->setSecret(md5(_uniqid()));
         }
 
         $siteURL = $this->getUrl();

--- a/objects/uploadArticleImage.php
+++ b/objects/uploadArticleImage.php
@@ -40,7 +40,7 @@ if (isset($_FILES['file_data']) && $_FILES['file_data']['error'] == 0) {
     }
 
     if (!empty($relativeDestinationDir)) {
-        $name = uniqid();
+        $name = _uniqid();
         $filename = $name . "." . strtolower($extension);
         $relativeDestinationDirFilename = $relativeDestinationDir . $filename;
         $destinationDir = $global['systemRootPath'] . $relativeDestinationDir;

--- a/objects/user.php
+++ b/objects/user.php
@@ -432,7 +432,7 @@ if (typeof gtag !== \"function\") {
         }
         if ($try > 10) {
             _error_log("User:_recommendChannelName too many tries ({$name}) (" . User::getId() . ") ", AVideoLog::$ERROR);
-            return uniqid();
+            return _uniqid();
         }
         if (empty($name)) {
             $name = self::getNameIdentification();
@@ -453,7 +453,7 @@ if (typeof gtag !== \"function\") {
         if (!Permissions::canAdminUsers()) {
             $user = self::getUserFromChannelName($name);
             if ($user && $user['id'] !== $users_id) {
-                return self::_recommendChannelName($name . "_" . uniqid(), $try + 1, $unknown, $users_id);
+                return self::_recommendChannelName($name . "_" . _uniqid(), $try + 1, $unknown, $users_id);
             }
         }
         return $name;
@@ -2480,7 +2480,7 @@ if (typeof gtag !== \"function\") {
         $userId = 0;
         if (!$userId = self::userExists($user)) {
             if (empty($pass)) {
-                $pass = uniqid();
+                $pass = _uniqid();
             }
             $pass = encryptPassword($pass);
             $userObject = new User(0, $user, $pass);
@@ -2535,7 +2535,7 @@ if (typeof gtag !== \"function\") {
     {
         $json = new stdClass();
         $json->id = $id;
-        $json->uniqid = uniqid();
+        $json->uniqid = _uniqid();
         $json->valid = strtotime("+{$secondsValid} seconds");
         _error_log("createRecoverPass " . getRealIpAddr() . ' ' . json_encode($_SERVER));
         return encryptString(json_encode($json));

--- a/objects/video.php
+++ b/objects/video.php
@@ -480,7 +480,7 @@ if (!class_exists('Video')) {
                 return false;
             }
             if (empty($this->title)) {
-                $this->title = uniqid();
+                $this->title = _uniqid();
             }
 
             $this->clean_title = _substr(safeString($this->clean_title), 0, 187);
@@ -4177,7 +4177,7 @@ if (!class_exists('Video')) {
                     TimeLogEnd($timeLog1, __LINE__, $timeLog1Limit);
                     $source['url'] = CDNStorage::getURL($f);
                     TimeLogEnd($timeLog1, __LINE__, $timeLog1Limit);
-                    //$source['url'] = addQueryStringParameter($source['url'], 'cache', uniqid());
+                    //$source['url'] = addQueryStringParameter($source['url'], 'cache', _uniqid());
                     $source['url_noCDN'] = $source['url'];
                     $source['line'] = __LINE__;
                 } elseif (!empty($yptStorage) && !empty($site) && $isValidType && $fsize < 20) {
@@ -4283,7 +4283,7 @@ if (!class_exists('Video')) {
                 $source = $videosPaths[$filename][$type][intval($includeS3)];
             }
             if (substr($type, -4) === ".jpg" || substr($type, -4) === ".png" || substr($type, -4) === ".gif" || substr($type, -4) === ".webp") {
-                $x = uniqid();
+                $x = _uniqid();
                 if (file_exists($source['path'])) {
                     $x = filemtime($source['path']) . filectime($source['path']);
                 } elseif (!empty($video)) {
@@ -4428,7 +4428,7 @@ if (!class_exists('Video')) {
 
         public static function getNewVideoFilename($prefix = '', $time = '')
         {
-            $uid = substr(uniqid(), -4);
+            $uid = substr(_uniqid(), -4);
             if (empty($time)) {
                 $time = time();
             }
@@ -6340,7 +6340,7 @@ if (!class_exists('Video')) {
                 $video['title'] = $evideo->title;
                 $video['clean_title'] = preg_replace('/[!#$&\'()*+,\\/:;=?@[\\] ]+/', '-', trim(mb_strtolower(cleanString($evideo->title))));
                 if (empty($evideo->description) && !empty($evideo->videos_id)) {
-                    $divId = uniqid();
+                    $divId = _uniqid();
                     $video['description'] = '<div id="' . $divId . '"></div>
                     <script>
                         $(document).ready(function () {
@@ -6819,7 +6819,7 @@ if (!class_exists('Video')) {
             $galleryDropDownMenu = Gallery::getVideoDropdownMenu($videos_id);
 
             $galleryVideoButtons .= '<!-- getVideoImagewithHoverAnimationFromVideosId -->';
-            $galleryVideoButtons .= '<div class="galleryVideoButtons ' . getCSSAnimationClassAndStyle('animate__flipInY', uniqid(), 0) . '">';
+            $galleryVideoButtons .= '<div class="galleryVideoButtons ' . getCSSAnimationClassAndStyle('animate__flipInY', _uniqid(), 0) . '">';
             $galleryVideoButtons .= self::generatePlaylistButtons($videos_id);
             if (Video::canEdit($videos_id)) {
                 $galleryVideoButtons .= '<div class="clearfix"></div>

--- a/plugin/AD_Server/AD_Server.php
+++ b/plugin/AD_Server/AD_Server.php
@@ -304,7 +304,7 @@ class AD_Server extends PluginAbstract
         $vmapURL = "{$global['webSiteRootURL']}plugin/AD_Server/VMAP.php";
         $vmapURL = addQueryStringParameter($vmapURL, 'video_length', $video_length);
         $vmapURL = addQueryStringParameter($vmapURL, 'vmap_id', $vmap_id);
-        $vmapURL = addQueryStringParameter($vmapURL, 'random', uniqid());
+        $vmapURL = addQueryStringParameter($vmapURL, 'random', _uniqid());
         $vmapURL = addQueryStringParameter($vmapURL, 'videos_id', $videos_id);
         $vmapURL = self::addVMAPS($vmapURL, $vmaps);
         //var_dump($vmapURL, $vmaps);exit;

--- a/plugin/AD_Server/VMAP.php
+++ b/plugin/AD_Server/VMAP.php
@@ -13,7 +13,7 @@ if (empty($_GET['video_length'])) {
 }
 
 if (empty($_GET['vmap_id'])) {
-    $_GET['vmap_id'] = uniqid();
+    $_GET['vmap_id'] = _uniqid();
 }
 
 $videos_id = getVideos_id();

--- a/plugin/AD_Server/footer.php
+++ b/plugin/AD_Server/footer.php
@@ -4,7 +4,7 @@
     if (typeof player === 'undefined' && $('#mainVideo').length) {
         player = videojs('mainVideo'<?php echo PlayerSkins::getDataSetup(); ?>);
     }
-    var options = {id: 'mainVideo', adTagUrl: webSiteRootURL+'plugin/AD_Server/VMAP.php?video_length=<?php echo $video_length ?>&vmap_id=<?php echo $vmap_id ?>&random=<?php echo uniqid(); ?>'};
+    var options = {id: 'mainVideo', adTagUrl: webSiteRootURL+'plugin/AD_Server/VMAP.php?video_length=<?php echo $video_length ?>&vmap_id=<?php echo $vmap_id ?>&random=<?php echo _uniqid(); ?>'};
         player.ima(options);
         $(document).ready(function () {
 

--- a/plugin/ADs/ADs.php
+++ b/plugin/ADs/ADs.php
@@ -166,7 +166,7 @@ class ADs extends PluginAbstract
             return "";
         }
         if (preg_match("/adsbygoogle/i", $adCode)) {
-            $uid = uniqid();
+            $uid = _uniqid();
             $adCode = str_replace("(adsbygoogle = window.adsbygoogle || []).push({});", "document.addEventListener(\"DOMContentLoaded\", function(event) {startGoogleAd('#adContainer{$uid}');});", trim($adCode));
             $adCode = "<div style='min-width:250px;min-height:90px;' id='adContainer{$uid}'>{$adCode}</div>";
         }
@@ -227,7 +227,7 @@ class ADs extends PluginAbstract
             return false;
         }
 
-        $fileName = uniqid();
+        $fileName = _uniqid();
 
         return ['fileName' => $fileName, 'path' => $paths['path'] . $fileName . '.png', 'url' => $paths['url'] . $fileName . '.png', 'txt' => $paths['path'] . $fileName . '.txt'];
     }
@@ -543,7 +543,7 @@ class ADs extends PluginAbstract
             return false;
         }
 
-        $id = 'myCarousel' . $type . uniqid();
+        $id = 'myCarousel' . $type . _uniqid();
 
         $size = self::getSize($type);
 

--- a/plugin/API/standAlone/functions.php
+++ b/plugin/API/standAlone/functions.php
@@ -163,7 +163,7 @@ function fixConcatFfmpegCommand($ffmpegCommand) {
 
         foreach ($concatFiles as $file) {
             if (preg_match('/^https?:\/\//', $file)) {
-                $localFile = getTmpDir().'concat_'.uniqid();
+                $localFile = getTmpDir().'concat_'._uniqid();
                 $data = url_get_contents($file);
                 file_put_contents($localFile, $data);
                 $fixedFiles[] = $localFile;

--- a/plugin/AVideoPlugin.php
+++ b/plugin/AVideoPlugin.php
@@ -1395,7 +1395,7 @@ class AVideoPlugin
         $plugins = Plugin::getAllEnabled();
         $userOptions = [];
         $navBarButtons = "";
-        $uid = uniqid();
+        $uid = _uniqid();
         foreach ($plugins as $value) {
             self::YPTstart($uid);
             $p = static::loadPlugin($value['dirName']);
@@ -1466,7 +1466,7 @@ class AVideoPlugin
         $p = static::loadPlugin($name);
         $btn = "";
         if (!empty($p)) {
-            $uid = uniqid();
+            $uid = _uniqid();
             $btn = '<div class="material-switch">
                     <input class="pluginSwitch" data-toggle="toggle" type="checkbox" id="subsSwitch' . $uid . '" value="1" ' . (self::isEnabledByName($name) ? "checked" : "") . ' >
                     <label for="subsSwitch' . $uid . '" class="label-primary"></label>

--- a/plugin/AdsForJesus/AdsForJesus.php
+++ b/plugin/AdsForJesus/AdsForJesus.php
@@ -113,7 +113,7 @@ class AdsForJesus extends PluginAbstract {
                 PlayerSkins::setIMAADTag($url);
             } else {
                 $video['duration'] = "01:00:00";
-                $_GET['videoName'] = "Live-" . uniqid();
+                $_GET['videoName'] = "Live-" . _uniqid();
                 $video_length = parseDurationToSeconds($video['duration']);
                 $obj = $this->getDataObject();
                 PlayerSkins::setIMAADTag("https://forjesus.tv/vmap.xml?video_durarion={$video_length}&start={$obj->start}&mid25Percent={$obj->mid25Percent}&mid50Percent={$obj->mid50Percent}&mid75Percent={$obj->mid75Percent}&end={$obj->end}");

--- a/plugin/CloneSite/cloneServer.json.php
+++ b/plugin/CloneSite/cloneServer.json.php
@@ -55,7 +55,7 @@ if (!is_dir($clonesDir)) {
     _error_log("Clone: dir {$clonesDir} already exists");
 }
 
-$resp->sqlFile = uniqid('Clone_mysqlDump_') . ".sql";
+$resp->sqlFile = _uniqid('Clone_mysqlDump_') . ".sql";
 // update this clone last request
 $resp->error = !$canClone->clone->updateLastCloneRequest();
 

--- a/plugin/CustomizeUser/actionButton.php
+++ b/plugin/CustomizeUser/actionButton.php
@@ -22,7 +22,7 @@ if ($obj->allowWalletDirectTransferDonation && !empty($video['users_id']) && cla
     <?php
     } elseif (class_exists("YPTWallet")) {
         $u = new User($video['users_id']);
-        $uid = uniqid();
+        $uid = _uniqid();
         $captcha = User::getCaptchaForm($uid);
         $live = isLive();
         if (!empty($live)) {

--- a/plugin/CustomizeUser/confirmDeleteUser.php
+++ b/plugin/CustomizeUser/confirmDeleteUser.php
@@ -68,7 +68,7 @@ $_page = new Page(array('Delete User', $user->getUser()));
             </div>
             <div class="panel-footer">
                 <?php
-                $uid = uniqid();
+                $uid = _uniqid();
                 $captcha = User::getCaptchaForm($uid, true);
                 ?>
                 <div class="form-group" id="captchaDeleteUser">

--- a/plugin/CustomizeUser/switchUserCanAllowFilesDownload.php
+++ b/plugin/CustomizeUser/switchUserCanAllowFilesDownload.php
@@ -1,5 +1,5 @@
 <?php
-$uid = uniqid();
+$uid = _uniqid();
 ?>
 <div class="material-switch">
     <input class="playerSwitchDefault" data-toggle="toggle" type="checkbox" value="" id="switch<?php echo $uid; ?>" <?php echo (CustomizeUser::canDownloadVideosFromUser($users_id)) ? "checked" : ""; ?>>

--- a/plugin/CustomizeUser/switchUserCanAllowFilesShare.php
+++ b/plugin/CustomizeUser/switchUserCanAllowFilesShare.php
@@ -1,5 +1,5 @@
 <?php
-$uid = uniqid();
+$uid = _uniqid();
 ?>
 <div class="material-switch">
     <input class="playerSwitchDefault" data-toggle="toggle" type="checkbox" value="" id="switch<?php echo $uid; ?>" <?php echo (CustomizeUser::canShareVideosFromUser($users_id)) ? "checked" : ""; ?>>

--- a/plugin/Gallery/functions.php
+++ b/plugin/Gallery/functions.php
@@ -35,7 +35,7 @@ function createGallery($title, $sort, $rowCount, $getName, $mostWord, $lessWord,
         $rowCount = intval($_GET['infiniteScrollRowCount']);
     }
 
-    $uid = "gallery" . uniqid();
+    $uid = "gallery" . _uniqid();
 ?>
     <div class="clear clearfix galeryRowElement" id="<?php echo $uid; ?>">
         <?php

--- a/plugin/Gallery/view/BigVideo.php
+++ b/plugin/Gallery/view/BigVideo.php
@@ -1,6 +1,6 @@
 <?php
 if (empty($crc)) {
-    $crc = uniqid();
+    $crc = _uniqid();
 }
 $suggestedOrPinnedFound = false;
 if ($obj->BigVideo && empty($_GET['showOnly'])) {

--- a/plugin/Gallery/view/mainAreaCategory.php
+++ b/plugin/Gallery/view/mainAreaCategory.php
@@ -79,7 +79,7 @@ function createCategorySection($videos)
                 </a>
                 <?php
                 if (!isHTMLEmpty($videos[0]['category_description'])) {
-                    $duid = uniqid();
+                    $duid = _uniqid();
                     $titleAlert = str_replace(array('"', "'"), array('``', "`"), $videos[0]['category']);
                 ?>
                     <a href="#" class="pull-right" onclick='avideoAlert("<?php echo $titleAlert; ?>", "<div style=\"max-height: 300px; overflow-y: scroll;overflow-x: hidden;\" id=\"categoryDescriptionAlertContent<?php echo $duid; ?>\" ></div>", "");$("#categoryDescriptionAlertContent<?php echo $duid; ?>").html($("#categoryDescription<?php echo $duid; ?>").html());return false;'><i class="far fa-file-alt"></i> <?php echo __("Description"); ?></a>

--- a/plugin/Gallery/view/videoDropDownMenu.php
+++ b/plugin/Gallery/view/videoDropDownMenu.php
@@ -7,7 +7,7 @@ $lis = array();
 if ((!empty($video['description'])) && !empty($obj->Description)) {
     $desc = nl2br(trim($video['description']));
     if (!isHTMLEmpty($desc)) {
-        $duid = uniqid();
+        $duid = _uniqid();
         $titleAlert = str_replace(array('"', "'"), array('``', "`"), $video['title']);
         $descTitle = __("Description");
         $lis[] = "

--- a/plugin/ImageGallery/ImageGallery.php
+++ b/plugin/ImageGallery/ImageGallery.php
@@ -92,7 +92,7 @@ class ImageGallery extends PluginAbstract
             // Generate unique filename to avoid overwriting
             $extension = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
             do {
-                $newFilename = uniqid() . '.' . $extension;
+                $newFilename = _uniqid() . '.' . $extension;
                 $newFilePath = $directory . $newFilename;
             } while (file_exists($newFilePath));
 

--- a/plugin/Layout/Layout.php
+++ b/plugin/Layout/Layout.php
@@ -142,7 +142,7 @@ class Layout extends PluginAbstract
         }
 
         $content = file_get_contents($global['systemRootPath'] . 'plugin/Layout/loaders/' . $name . '.html');
-        return trim(preg_replace('/\s+/', ' ', str_replace('lds-', 'lds-' . uniqid(), $content)));
+        return trim(preg_replace('/\s+/', ' ', str_replace('lds-', 'lds-' . _uniqid(), $content)));
     }
 
     static function getLoaderDefault()
@@ -333,7 +333,7 @@ class Layout extends PluginAbstract
         $getIconsSelect = 1;
         $icons = self::getIconsList();
         if (empty($id)) {
-            $id = uniqid();
+            $id = _uniqid();
         }
 
         $html = self::getSearch2Code($id);
@@ -406,7 +406,7 @@ class Layout extends PluginAbstract
         }
 
         if (empty($id)) {
-            $id = uniqid();
+            $id = _uniqid();
         }
 
         if ($selected == 'us') {
@@ -470,7 +470,7 @@ class Layout extends PluginAbstract
             }
         }
         if (empty($id)) {
-            $id = uniqid();
+            $id = _uniqid();
         }
         $html = self::getSearch2Code($id);
         self::addFooterCode($html);
@@ -490,7 +490,7 @@ class Layout extends PluginAbstract
             $cats[$value['id']] = htmlentities("<i class='{$value['iconClass']}'></i> " . $value['hierarchyAndName']);
         }
         if (empty($id)) {
-            $id = uniqid();
+            $id = _uniqid();
         }
 
         $html = self::getSearch2Code($id);
@@ -502,7 +502,7 @@ class Layout extends PluginAbstract
     {
         $rows = UserGroups::getAllUsersGroupsArray();
         if (empty($id)) {
-            $id = uniqid();
+            $id = _uniqid();
         }
         $html = self::getSearch2Code($id);
         self::addFooterCode($html);
@@ -580,7 +580,7 @@ class Layout extends PluginAbstract
         global $global;
         $default_Playlists_id = intval($default_Playlists_id);
         if (empty($id)) {
-            $id = 'getPlaylistAutocomplete_' . uniqid();
+            $id = 'getPlaylistAutocomplete_' . _uniqid();
         }
         include $global['systemRootPath'] . 'plugin/Layout/playlistAutocomplete.php';
         return "updatePlaylistAutocomplete{$id}();";
@@ -591,7 +591,7 @@ class Layout extends PluginAbstract
         global $global;
         $default_users_id = intval($default_users_id);
         if (empty($id)) {
-            $id = 'getUserAutocomplete_' . uniqid();
+            $id = 'getUserAutocomplete_' . _uniqid();
         }
         include $global['systemRootPath'] . 'plugin/Layout/userAutocomplete.php';
         return "updateUserAutocomplete{$id}();";
@@ -602,7 +602,7 @@ class Layout extends PluginAbstract
         global $global;
         $default_videos_id = intval($default_videos_id);
         if (empty($id)) {
-            $id = 'getVideoAutocomplete_' . uniqid();
+            $id = 'getVideoAutocomplete_' . _uniqid();
         }
         include $global['systemRootPath'] . 'plugin/Layout/videoAutocomplete.php';
         return "updateVideoAutocomplete{$id}();";
@@ -881,7 +881,7 @@ class Layout extends PluginAbstract
     static function getSearchOptions($name)
     {
         $divs = array();
-        $id = str_replace('[]', '', $name) . uniqid();
+        $id = str_replace('[]', '', $name) . _uniqid();
         foreach (Layout::$searchOptions as $key => $value) {
 
             $divs[] = '<div class="form-check">
@@ -897,7 +897,7 @@ class Layout extends PluginAbstract
     {
         global $global;
         $divs = array();
-        $id = str_replace('[]', '', $name) . uniqid();
+        $id = str_replace('[]', '', $name) . _uniqid();
 
         $divs[] = '<div class="form-check">
                         <label class="form-check-label">
@@ -922,7 +922,7 @@ class Layout extends PluginAbstract
     {
         global $global;
         $divs = array();
-        $id = str_replace('[]', '', $name) . uniqid();
+        $id = str_replace('[]', '', $name) . _uniqid();
 
         $divs[] = '<div class="form-check">
                         <label class="form-check-label">
@@ -976,7 +976,7 @@ class Layout extends PluginAbstract
         }
 
         $divs = array();
-        $id = str_replace('[]', '', $name) . uniqid();
+        $id = str_replace('[]', '', $name) . _uniqid();
 
         $divs[] = '<div class="form-check">
                         <label class="form-check-label">
@@ -1008,7 +1008,7 @@ class Layout extends PluginAbstract
             return array();
         }
         $divs = array();
-        $id = str_replace('[]', '', $name) . uniqid();
+        $id = str_replace('[]', '', $name) . _uniqid();
         $divs[] = '<div class="form-check">
                         <label class="form-check-label">
                         <input class="form-check-input" type="radio" name="' . $name . '" checked value=""> 
@@ -1026,7 +1026,7 @@ class Layout extends PluginAbstract
 
     static function getSearchHTML($elements, $name)
     {
-        $id = 'search_' . uniqid();
+        $id = 'search_' . _uniqid();
         $class = 'searchHTML' . str_replace('[]', '', $name);
 ?>
         <div class="panel panel-default searchHTML <?php echo $class; ?>" id="<?php echo $id; ?>-panel" style="margin: 0;">

--- a/plugin/Live/Live.php
+++ b/plugin/Live/Live.php
@@ -915,7 +915,7 @@ Click <a href=\"{link}\">here</a> to join our live.";
             return '';
         }
         global $global;
-        $id = "getButton" . uniqid();
+        $id = "getButton" . _uniqid();
         $afterLabel = "";
         $obj = AVideoPlugin::getDataObject('Live');
         switch ($command) {

--- a/plugin/Live/Objects/LiveTransmition.php
+++ b/plugin/Live/Objects/LiveTransmition.php
@@ -184,7 +184,7 @@ class LiveTransmition extends ObjectYPT {
             $l = new LiveTransmition(0);
             $l->setTitle("I am Live");
             $l->setDescription("");
-            $l->setKey(uniqid());
+            $l->setKey(_uniqid());
             $l->setCategories_id(1);
             $l->setUsers_id($user_id);
             $l->setPublicAutomatic();
@@ -203,7 +203,7 @@ class LiveTransmition extends ObjectYPT {
         $row = static::getFromDbByUser($user_id);
 
         $l = new LiveTransmition($row['id']);
-        $newKey = uniqid();
+        $newKey = _uniqid();
         $l->setKey($newKey);
         if ($l->save()) {
             return $newKey;

--- a/plugin/Live/Objects/LiveTransmitionHistory.php
+++ b/plugin/Live/Objects/LiveTransmitionHistory.php
@@ -918,7 +918,7 @@ class LiveTransmitionHistory extends ObjectYPT
             $latest = self::getLatestFromUser($this->users_id);
             if(empty($latest)){
                 _error_log("LiveTransmitionHistory::save: ERROR again, no latest key found");
-                $this->key = uniqid();
+                $this->key = _uniqid();
             }else{
                 $this->key = $latest['key'];
             }

--- a/plugin/Live/Objects/Live_schedule.php
+++ b/plugin/Live/Objects/Live_schedule.php
@@ -434,7 +434,7 @@ class Live_schedule extends ObjectYPT
         }
 
         if (empty($this->key)) {
-            $this->key = uniqid();
+            $this->key = _uniqid();
         }
 
         $this->_setTimeZone(date_default_timezone_get());

--- a/plugin/Live/calendar.json.php
+++ b/plugin/Live/calendar.json.php
@@ -169,7 +169,7 @@ foreach ($appArray as $app) {
         //var_dump($app['type']);
         $isPlayingNow = empty($app['comingsoon']);
 
-        $id = $app['liveLinks_id'] ?? $app['live_schedule_id'] ?? uniqid('live_');
+        $id = $app['liveLinks_id'] ?? $app['live_schedule_id'] ?? _uniqid('live_');
         
         // Determine start and end timestamps
         $startTimestamp = $isPlayingNow ? time() : strtotime($app['start_date'] ?? $app['scheduled_time'] ?? 'now');

--- a/plugin/Live/latestOrLive.php
+++ b/plugin/Live/latestOrLive.php
@@ -122,7 +122,7 @@ if (!$liveFound && AVideoPlugin::isEnabledByName('LiveLinks')) {
         $objectToReturnToParentIframe->mediaSession = LiveLinks::getMediaSession($video['id']);
         $objectToReturnToParentIframe->users_id = intval($video['users_id']);
         $liveFound = true;
-        $isLiveLink = uniqid();
+        $isLiveLink = _uniqid();
     }
 }
 if (!$liveFound) {

--- a/plugin/Live/on_publish.php
+++ b/plugin/Live/on_publish.php
@@ -168,7 +168,7 @@ if (!empty($obj) && empty($obj->error)) {
         _error_log("NGINX ON Publish redirect");
         http_response_code(302);
         header("HTTP/1.0 302 Publish Here");
-        $newKey = $_POST['name'].'-'. uniqid();
+        $newKey = $_POST['name'].'-'. _uniqid();
         header("Location: rtmp://192.168.1.18/live/$newKey/?p={$_GET['p']}");
         exit;
     }

--- a/plugin/Live/standAloneFiles/saveDVR.json.php
+++ b/plugin/Live/standAloneFiles/saveDVR.json.php
@@ -53,7 +53,7 @@ error_reporting(E_ALL & ~E_DEPRECATED);
 
 $filename = $record_path . $file . '_' . (date('Y-m-d-H-i-s')) . ".mp4";
 $DVRFile = "{$hls_path}{$key}";
-$tmpDVRDir = $record_path . $file . uniqid();
+$tmpDVRDir = $record_path . $file . _uniqid();
 
 $isAdaptive = !is_dir($DVRFile);
 

--- a/plugin/Live/view/Live_restreams/testRestreamer.json.php
+++ b/plugin/Live/view/Live_restreams/testRestreamer.json.php
@@ -21,7 +21,7 @@ _error_log('Testing reestream users_id=['.User::getId().'] '.json_encode(debug_b
 $lth = new LiveTransmitionHistory();
 $lth->setTitle('Restream test '.date('Y-m-d H:i:s'));
 $lth->setDescription('');
-$lth->setKey(uniqid());
+$lth->setKey(_uniqid());
 $lth->setDomain('localhost');
 $lth->setUsers_id(User::getId());
 $lth->setLive_servers_id(Live::getLiveServersIdRequest());

--- a/plugin/Live/view/modeYoutubeLive.php
+++ b/plugin/Live/view/modeYoutubeLive.php
@@ -73,7 +73,7 @@ if (!empty($_REQUEST['live_schedule'])) {
     //$liveImg = Live_schedule::getPosterURL($_REQUEST['live_schedule'], 0);
     $liveUrl = addQueryStringParameter($liveUrl, 'live_schedule', intval($_REQUEST['live_schedule']));
     $img = addQueryStringParameter($img, 'live_schedule', intval($_REQUEST['live_schedule']));
-    $img = addQueryStringParameter($img, 'cache', uniqid());
+    $img = addQueryStringParameter($img, 'cache', _uniqid());
     global $getLiveKey;
     $getLiveKey = ['key' => $ls->getKey(), 'live_servers_id' => intval($ls->getLive_servers_id()), 'live_index' => '', 'cleanKey' => ''];
 

--- a/plugin/LiveLinks/view/Live.php
+++ b/plugin/LiveLinks/view/Live.php
@@ -33,7 +33,7 @@ if (!empty($_GET['link'])) {
     $date = convertFromDefaultTimezoneTimeToMyTimezone($liveLink->getStart_date());
     $toTime = strtotime($date);
 } else {
-    $isLiveLink = uniqid();
+    $isLiveLink = _uniqid();
     $uuid = $isLiveLink;
     $t = LiveLinks::decodeDinamicVideoLink();
     $toTime = time();

--- a/plugin/LoginControl/LoginControl.php
+++ b/plugin/LoginControl/LoginControl.php
@@ -182,7 +182,7 @@ Best regards,
                 _error_log("LoginControl::getConfirmationCode wrong modification is too old [{$row['modified']}] ");
             }
         }
-        return uniqid();
+        return _uniqid();
     }
 
     public static function is2FAEnabled($users_id) {
@@ -523,7 +523,7 @@ Best regards,
         }
         _session_start();
         if (empty($_SESSION['user']['challenge']['text'])) {
-            $_SESSION['user']['challenge']['text'] = uniqid();
+            $_SESSION['user']['challenge']['text'] = _uniqid();
             $_SESSION['user']['challenge']['isComplete'] = false;
         }
         $encMessage = self::encryptPGPMessage(User::getId(), $_SESSION['user']['challenge']['text']);

--- a/plugin/LoginControl/switchUser2FA.php
+++ b/plugin/LoginControl/switchUser2FA.php
@@ -1,5 +1,5 @@
 <?php
-$uid = uniqid();
+$uid = _uniqid();
 ?>
 <div class="material-switch">
     <input class="playerSwitchDefault" data-toggle="toggle" type="checkbox" value="" id="switch<?php echo $uid; ?>" <?php echo (LoginControl::is2FAEnabled($users_id)) ? "checked" : ""; ?>>

--- a/plugin/Meet/Meet.php
+++ b/plugin/Meet/Meet.php
@@ -601,7 +601,7 @@ Passcode: {password}
     {
         global $global;
         if (empty($id)) {
-            $id = "avideoMeet" . uniqid();
+            $id = "avideoMeet" . _uniqid();
         }
         $svgContent = file_get_contents($global['systemRootPath'] . 'plugin/Meet/buttons/' . $svg);
         $btn = '<div class="toolbox-button aVideoMeet ' . $class . '" tabindex="0" role="button" onclick="' . $onclick . '" id="' . $id . '" style="' . $style . '">'

--- a/plugin/Meet/saveMeet.json.php
+++ b/plugin/Meet/saveMeet.json.php
@@ -75,7 +75,7 @@ $o->setPassword(@$_REQUEST['RoomPasswordNew']);
 $o->setTopic(@$_REQUEST['RoomTopic']);
 $o->setStarts($_REQUEST['starts']);
 $o->setName($obj->roomName);
-$o->setMeet_code(uniqid());
+$o->setMeet_code(_uniqid());
 $meet_schedule_id = $o->save();
 if ($meet_schedule_id) {
     Meet_schedule_has_users_groups::saveUsergroupsToMeet($meet_schedule_id, $_REQUEST['userGroups']);

--- a/plugin/Meet/uploadRecordedVideo.json.php
+++ b/plugin/Meet/uploadRecordedVideo.json.php
@@ -59,7 +59,7 @@ error_log(__FILE__ . " line " . __LINE__);
 $userObject = new User($users_id);
 $userObject->login(true, true);
 
-$tmpFile = getTmpDir() . uniqid();
+$tmpFile = getTmpDir() . _uniqid();
 
 error_log(__FILE__ . " line " . __LINE__);
 if (move_uploaded_file($_FILES['upl']['tmp_name'], $tmpFile)) {

--- a/plugin/PayPalYPT/ipn.php
+++ b/plugin/PayPalYPT/ipn.php
@@ -23,7 +23,7 @@ if (empty($_POST["recurring_payment_id"])) {
     _error_log("PayPalIPN: recurring_payment_id EMPTY ");
     $users_id = User::getId();
 
-    $invoiceNumber = uniqid();
+    $invoiceNumber = _uniqid();
 
     $payment = $paypal->execute();
     //var_dump($amount);

--- a/plugin/PayPalYPT/payOutReceiverEmailForm.php
+++ b/plugin/PayPalYPT/payOutReceiverEmailForm.php
@@ -1,5 +1,5 @@
 <?php
-$uid = uniqid();
+$uid = _uniqid();
 ?>
 <div class="form-group">
     <label class="col-md-4 control-label"><?php echo __("PayPal payout email"); ?></label>

--- a/plugin/Permissions/getPermissionsFromPlugin.html.php
+++ b/plugin/Permissions/getPermissionsFromPlugin.html.php
@@ -18,7 +18,7 @@ if (empty($_REQUEST['plugins_id'])) {
 $obj = AVideoPlugin::getObjectDataIfEnabled("Permissions");
 $permissions = Permissions::getPluginPermissions($_REQUEST['plugins_id']);
 $userGroups = UserGroups::getAllUsersGroupsArray();
-$uid = uniqid();
+$uid = _uniqid();
 ?>
 <div class="panel panel-default">
     <div class="panel-heading tabbable-line">

--- a/plugin/PlayLists/PlayLists.php
+++ b/plugin/PlayLists/PlayLists.php
@@ -287,7 +287,7 @@ class PlayLists extends PluginAbstract
             $filename = $video['filename'];
             $v = new Video("", "", $video['id']);
         } else {
-            $filename = 'serie_playlists_' . uniqid();
+            $filename = 'serie_playlists_' . _uniqid();
             $v = new Video("", $filename);
         }
         $v->setTitle($playlist->getName());
@@ -755,7 +755,7 @@ class PlayLists extends PluginAbstract
             return '';
         }
         global $global;
-        $uid = uniqid();
+        $uid = _uniqid();
         $totalDuration = 0;
         foreach ($playListArray as $value) {
             $totalDuration += $value['duration_seconds'];
@@ -810,7 +810,7 @@ class PlayLists extends PluginAbstract
         $className = "class_{$uid}";
         $epgBars = "";
         foreach ($playListArray as $key => $value) {
-            $epgId = "epg_" . uniqid();
+            $epgId = "epg_" . _uniqid();
             $represents_percentage = number_format(($value['duration_seconds'] / $totalDuration) * 100, 2);
             $images = Video::getImageFromFilename($value['filename']);
             $per += $represents_percentage;
@@ -859,7 +859,7 @@ class PlayLists extends PluginAbstract
             return "";
         }
         global $global;
-        $btnId = "btnId" . uniqid();
+        $btnId = "btnId" . _uniqid();
         $label = __("Play Live");
         $tooltip = __("Play this Program live now");
         $liveLink = PlayLists::getLiveLink($playlists_id);

--- a/plugin/PlayLists/actionButton.php
+++ b/plugin/PlayLists/actionButton.php
@@ -12,7 +12,7 @@ $global['laodPlaylistScript'] = 1;
     <div class="webui-popover-content">
         <?php
         if (User::isLogged()) {
-            $uniqId = uniqid();
+            $uniqId = _uniqid();
         ?>
             <form role="form">
                 <div class="form-group">

--- a/plugin/UserNotifications/Objects/User_notifications.php
+++ b/plugin/UserNotifications/Objects/User_notifications.php
@@ -174,7 +174,7 @@ class User_notifications extends ObjectYPT {
 
     public function save() {
         if (empty($this->element_id)) {
-            $this->element_id = 'automatic_id_' . uniqid();
+            $this->element_id = 'automatic_id_' . _uniqid();
         }else{
             if(self::elementIdExists($this->element_id)){
                 return false;

--- a/plugin/YPTSocket/Message.php
+++ b/plugin/YPTSocket/Message.php
@@ -303,7 +303,7 @@ class Message implements MessageComponentInterface {
             $obj['msg'] = $msg;
         }
 
-        $obj['uniqid'] = uniqid();
+        $obj['uniqid'] = _uniqid();
         $obj['users_id'] = $users_id;
         $obj['videos_id'] = $videos_id;
         $obj['live_key'] = $live_key;
@@ -425,7 +425,7 @@ class Message implements MessageComponentInterface {
                     $return['users_uri'][$index][$client['yptDeviceId']] = array();
                 }
                 if (empty($client['users_id'])) {
-                    $return['users_uri'][$index][$client['yptDeviceId']][uniqid()] = $client;
+                    $return['users_uri'][$index][$client['yptDeviceId']][_uniqid()] = $client;
                 } else
                 if (!isset($return['users_uri'][$index][$client['yptDeviceId']][$client['users_id']])) {
                     $return['users_uri'][$index][$client['yptDeviceId']][$client['users_id']] = $client;

--- a/plugin/YPTSocket/MessageSQLite.php
+++ b/plugin/YPTSocket/MessageSQLite.php
@@ -357,7 +357,7 @@ class Message implements MessageComponentInterface {
             $obj['msg'] = $msg;
         }
 
-        $obj['uniqid'] = uniqid();
+        $obj['uniqid'] = _uniqid();
         $obj['users_id'] = $users_id;
         $obj['videos_id'] = $videos_id;
         $obj['live_key'] = $live_key;

--- a/plugin/YPTSocket/MessageSQLiteV2.php
+++ b/plugin/YPTSocket/MessageSQLiteV2.php
@@ -392,7 +392,7 @@ class Message implements MessageComponentInterface
             $obj['msg'] = $msg;
         }
 
-        $obj['uniqid'] = uniqid();
+        $obj['uniqid'] = _uniqid();
         $obj['users_id'] = $users_id;
         $obj['videos_id'] = $videos_id;
         $obj['live_key'] = $live_key;

--- a/plugin/YPTSocket/test.php
+++ b/plugin/YPTSocket/test.php
@@ -148,7 +148,7 @@ function _test_getEncryptedInfo($msg) {
     $msgObj->test_msg = $msg;
     $msgObj->user_name = SocketMessageType::TESTING;
     $msgObj->browser = SocketMessageType::TESTING;
-    $msgObj->yptDeviceId = SocketMessageType::TESTING . "-" . uniqid();
+    $msgObj->yptDeviceId = SocketMessageType::TESTING . "-" . _uniqid();
     $msgObj->token = getToken($timeOut);
     $msgObj->time = time();
     $msgObj->ip = '127.0.0.1';

--- a/plugin/YPTWallet/YPTWallet.php
+++ b/plugin/YPTWallet/YPTWallet.php
@@ -701,7 +701,7 @@ class YPTWallet extends PluginAbstract
     {
         global $global;
         $identification = User::getNameIdentificationById($from_users_id);
-        $element_id = "transactionNotification" . uniqid();
+        $element_id = "transactionNotification" . _uniqid();
 
         // Set default values for title, message, icon, and type
         $title = 'Transaction Notification';

--- a/plugin/YPTWallet/plugins/YPTWalletPayPal/confirmRecurrentButton.php
+++ b/plugin/YPTWallet/plugins/YPTWalletPayPal/confirmRecurrentButton.php
@@ -1,5 +1,5 @@
 <?php
-$uniqid = uniqid();
+$uniqid = _uniqid();
 $obj = AVideoPlugin::getObjectData("PayPalYPT");
 ?>
 <button type="submit" class="btn btn-primary" id="YPTWalletPayPalRecurrentButton<?php echo $uniqid; ?>"><i class="fab fa-paypal"></i> <?php echo __($obj->subscriptionButtonLabel); ?></button>

--- a/plugin/YPTWallet/plugins/YPTWalletPayPal/confirmRecurrentButtonV2.php
+++ b/plugin/YPTWallet/plugins/YPTWalletPayPal/confirmRecurrentButtonV2.php
@@ -1,5 +1,5 @@
 <?php
-$uniqid = uniqid();
+$uniqid = _uniqid();
 $obj = AVideoPlugin::getObjectData("PayPalYPT");
 
 $params = array('total'=>$total, 'currency'=>$currency, 'frequency'=>$frequency, 'interval'=>$interval, 'name'=>$name, 'json'=>$json, 'trialDays'=>$trialDays, 'addFunds_Success'=>$addFunds_Success);

--- a/plugin/YPTWallet/plugins/YPTWalletPayPal/redirect_url.php
+++ b/plugin/YPTWallet/plugins/YPTWalletPayPal/redirect_url.php
@@ -13,7 +13,7 @@ $paypal = AVideoPlugin::loadPluginIfEnabled("PayPalYPT");
 // how to get the users_ID from the PayPal call back IPN?
 $users_id = User::getId();
 
-$invoiceNumber = uniqid();
+$invoiceNumber = _uniqid();
 
 $payment = $paypal->execute();
 

--- a/plugin/YPTWallet/plugins/YPTWalletPayPal/requestPayment.json.php
+++ b/plugin/YPTWallet/plugins/YPTWalletPayPal/requestPayment.json.php
@@ -24,7 +24,7 @@ if(!empty($_REQUEST['videos_id'])){
     YPTWallet::setAddFundsSuccessRedirectToVideo($_REQUEST['videos_id']);
 }
 
-$invoiceNumber = uniqid();
+$invoiceNumber = _uniqid();
 
 $description = $config->getWebSiteTitle()." Payment";
 

--- a/plugin/YPTWallet/plugins/YPTWalletPayPal/requestSubscription.json.php
+++ b/plugin/YPTWallet/plugins/YPTWalletPayPal/requestSubscription.json.php
@@ -15,7 +15,7 @@ $objS = $pluginS->getDataObject();
 $obj= new stdClass();
 $obj->error = true;
 
-$invoiceNumber = uniqid();
+$invoiceNumber = _uniqid();
 if (session_status() == PHP_SESSION_NONE) {
     session_start();
 }

--- a/plugin/YPTWallet/plugins/YPTWalletPayPal/requestSubscriptionV2.json.php
+++ b/plugin/YPTWallet/plugins/YPTWalletPayPal/requestSubscriptionV2.json.php
@@ -16,7 +16,7 @@ $obj= new stdClass();
 $obj->error = true;
 $obj->msg = '';
 
-$invoiceNumber = uniqid();
+$invoiceNumber = _uniqid();
 
 //$params = array('total'=>$total, 'currency'=>$currency, 'frequency'=>$frequency, 'interval'=>$interval, 'name'=>$name, 'json'=>$json, 'trialDays'=>$trialDays);
 

--- a/plugin/YPTWallet/plugins/YPTWalletRazorPay/confirmRecurrentButton.php
+++ b/plugin/YPTWallet/plugins/YPTWalletRazorPay/confirmRecurrentButton.php
@@ -1,6 +1,6 @@
 <?php
 $obj = AVideoPlugin::getObjectData('StripeYPT');
-$uid = uniqid();
+$uid = _uniqid();
 ?>
 <form method="post" action="<?php echo $global['webSiteRootURL']; ?>plugin/YPTWallet/plugins/YPTWalletRazorPay/requestSubscription.json.php" style="display:none;" id="RazorPayForm<?php echo $uid; ?>">
     <input type="text" name="value" value="" id="valueRazorPay<?php echo $uid; ?>" autocomplete="off"/>

--- a/plugin/YPTWallet/plugins/YPTWalletRazorPay/requestPayment.json.php
+++ b/plugin/YPTWallet/plugins/YPTWalletRazorPay/requestPayment.json.php
@@ -25,7 +25,7 @@ $api = new Api($obj->api_key, $obj->api_secret);
 // We create an razorpay order using orders api
 // Docs: https://docs.razorpay.com/docs/orders
 //
-$invoiceNumber = uniqid();
+$invoiceNumber = _uniqid();
 
 $displayCurrency = $objS->currency;
 

--- a/plugin/YPTWallet/plugins/YPTWalletRazorPay/requestSubscription.json.php
+++ b/plugin/YPTWallet/plugins/YPTWalletRazorPay/requestSubscription.json.php
@@ -17,7 +17,7 @@ $obj->error = true;
 $displayCurrency = $objS->currency;
 
 
-$invoiceNumber = uniqid();
+$invoiceNumber = _uniqid();
 if (session_status() == PHP_SESSION_NONE) {
     session_start();
 }

--- a/plugin/YPTWallet/plugins/YPTWalletStripe/confirmButton.php
+++ b/plugin/YPTWallet/plugins/YPTWalletStripe/confirmButton.php
@@ -1,6 +1,6 @@
 <?php
 $obj = AVideoPlugin::getObjectData('StripeYPT');
-$uid = uniqid();
+$uid = _uniqid();
 ?>
 <style>
     /**

--- a/plugin/YPTWallet/plugins/YPTWalletStripe/confirmRecurrentButton.php
+++ b/plugin/YPTWallet/plugins/YPTWalletStripe/confirmRecurrentButton.php
@@ -1,7 +1,7 @@
 <?php
 global $planTitle;
 $obj = AVideoPlugin::getObjectData('StripeYPT');
-$uid = uniqid();
+$uid = _uniqid();
 ?>
 <style>
     /**

--- a/plugin/YPTWallet/plugins/YPTWalletStripe/requestPayment.json.php
+++ b/plugin/YPTWallet/plugins/YPTWalletStripe/requestPayment.json.php
@@ -20,7 +20,7 @@ if (empty($_POST['value'])) {
     die(json_encode($obj));
 }
 
-$invoiceNumber = uniqid();
+$invoiceNumber = _uniqid();
 //setUpPayment($total = '1.00', $currency = "USD", $description = "");
 $payment = $plugin->setUpPayment($_POST['value'], $objS->currency, $config->getWebSiteTitle() . " Payment");
 

--- a/plugin/YPTWallet/plugins/YPTWalletStripe/requestSubscription.json.php
+++ b/plugin/YPTWallet/plugins/YPTWalletStripe/requestSubscription.json.php
@@ -20,7 +20,7 @@ $obj->msg = "";
 $obj->customer = false;
 $obj->plans_id = intval(@$_REQUEST['plans_id']);
 
-$invoiceNumber = uniqid();
+$invoiceNumber = _uniqid();
 if (session_status() == PHP_SESSION_NONE) {
     session_start();
 }

--- a/plugin/YouPHPFlix2/view/BigVideo.php
+++ b/plugin/YouPHPFlix2/view/BigVideo.php
@@ -1,6 +1,6 @@
 <?php
 global $advancedCustom;
-$uid = uniqid();
+$uid = _uniqid();
 $obj2 = AVideoPlugin::getObjectData("YouPHPFlix2");
 
 if (!empty($global['isChannel'])) {

--- a/plugin/YouPHPFlix2/view/modeFlixCategory.php
+++ b/plugin/YouPHPFlix2/view/modeFlixCategory.php
@@ -21,14 +21,14 @@ $cacheName .= isForKidsSet()?'forKids':'';
 
 $cache = ObjectYPT::getCache($cacheName, 600);
 if (!empty($cache)) {
-    echo str_replace('{serie_uid}', uniqid(), $cache);
+    echo str_replace('{serie_uid}', _uniqid(), $cache);
     return false;
 }
 _ob_start();
 $obj = AVideoPlugin::getObjectData("YouPHPFlix2");
 $timeLog = __FILE__ . " - modeFlixCategory";
 
-$uid = uniqid();
+$uid = _uniqid();
 $divUUID = $uid;
 
 $ads2 = getAdsLeaderBoardTop2();
@@ -165,5 +165,5 @@ $cache = _ob_get_clean();
 
 ObjectYPT::setCache($cacheName, $cache);
 
-echo str_replace('{serie_uid}', uniqid(), $cache);
+echo str_replace('{serie_uid}', _uniqid(), $cache);
 ?>

--- a/plugin/YouPHPFlix2/view/modeFlixSerie.php
+++ b/plugin/YouPHPFlix2/view/modeFlixSerie.php
@@ -18,7 +18,7 @@ if (empty($video)) {
 }
 
 if (empty($_REQUEST['uid'])) {
-    $uid = uniqid();
+    $uid = _uniqid();
 } else {
     $uid = preg_replace('/[^a-z0-0_]/i', '', $_REQUEST['uid']);
 }
@@ -29,7 +29,7 @@ if (empty($_REQUEST['uid'])) {
   $cacheName = "modeFlixSerie" . md5(json_encode($_GET)) . User::getId();
   $cache = ObjectYPT::getCache($cacheName, 600);
   if (!empty($cache)) {
-  echo str_replace('{serie_uid}', uniqid(), $cache);
+  echo str_replace('{serie_uid}', _uniqid(), $cache);
   return false;
   }
   ob_start();
@@ -64,7 +64,7 @@ if (empty($videos)) {
     return;
 }
 
-$uidFlickirty = uniqid();
+$uidFlickirty = _uniqid();
 ?>
 <div class="row topicRow" id="<?php echo $uidFlickirty; ?>-Flickirty">
     <!-- Serie -->
@@ -88,7 +88,7 @@ $rowlinkEmbed = false;
 
   ObjectYPT::setCache($cacheName, $cache);
 
-  echo str_replace('{serie_uid}', uniqid(), $cache);
+  echo str_replace('{serie_uid}', _uniqid(), $cache);
  * 
  */
 ?>

--- a/plugin/YouPHPFlix2/view/row.php
+++ b/plugin/YouPHPFlix2/view/row.php
@@ -1,7 +1,7 @@
 <?php
 global $advancedCustom;
 
-$uidOriginal = uniqid();
+$uidOriginal = _uniqid();
 $landscape = "rowPortrait";
 $css = "";
 if (!empty($obj->landscapePosters)) {

--- a/view/ddosCaptcha.php
+++ b/view/ddosCaptcha.php
@@ -46,7 +46,7 @@ if (!empty($_SERVER['HTTP_USER_AGENT']) && preg_match("/AVideo(.*)/", $ua)) {
     return ;
 }
 
-$ip = uniqid();
+$ip = _uniqid();
 if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
     $ip = $_SERVER['HTTP_CLIENT_IP'];
 } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {

--- a/view/include/playlist.php
+++ b/view/include/playlist.php
@@ -132,7 +132,7 @@ if (!empty($videoSerie)) {
                     $class .= " active";
                     $indicator = '<span class="fa fa-play text-danger"></span>';
                 }
-                $uid = 'pl_' . uniqid();
+                $uid = 'pl_' . _uniqid();
                 $plURL = PlayLists::getURL($playlist_id, $count, $value["channelName"], $playlist->getName(), $value['clean_title']);
             ?>
                 <li class="<?php echo $class; ?>" id="<?php echo $uid; ?>">

--- a/view/include/social.php
+++ b/view/include/social.php
@@ -65,7 +65,7 @@ $social_medias = [
 ?>
 <ul class="social-network social-circle social-bgColor">
     <?php
-    $loaderSequenceName = uniqid();
+    $loaderSequenceName = _uniqid();
     foreach ($global['social_medias'] as $key => $value) {
         eval("\$show = \$advancedCustom->showShareButton_{$key};");
         if (empty($show)) {
@@ -87,6 +87,6 @@ $social_medias = [
 </ul>
 <div style="margin-top: 10px;">
     <?php
-    getInputCopyToClipboard(uniqid(), $urlShort, 'class="form-control" readonly="readonly" style="background-color: #EEE; color: #000;"');
+    getInputCopyToClipboard(_uniqid(), $urlShort, 'class="form-control" readonly="readonly" style="background-color: #EEE; color: #000;"');
     ?>
 </div>

--- a/view/logs.php
+++ b/view/logs.php
@@ -40,7 +40,7 @@ function e($text)
     $uniqid = '';
     $class = '';
     $collapsible = true;
-    $uniqid = uniqid();
+    $uniqid = _uniqid();
     if (
             preg_match("/(AVideoLog::SECURITY)/", $text, $matches) ||
             preg_match("/(Prepare failed)/i", $text, $matches) ||

--- a/view/mini-upload-form/imageUpload.json.php
+++ b/view/mini-upload-form/imageUpload.json.php
@@ -50,7 +50,7 @@ if (!empty($_FILES['comment_image']) && $_FILES['comment_image']['error'] === UP
     }
 
     // Sanitize file name
-    $newFileName = uniqid('comment_img_') . '_user_' . $users_id . '.' . $fileExt;
+    $newFileName = _uniqid('comment_img_') . '_user_' . $users_id . '.' . $fileExt;
     $destPath = $targetDir . $newFileName;
 
     // Move the uploaded file

--- a/view/mini-upload-form/upload.php
+++ b/view/mini-upload-form/upload.php
@@ -31,7 +31,7 @@ if (isset($_FILES['upl']) && $_FILES['upl']['error'] == 0) {
     $duration = Video::getDurationFromFile($_FILES['upl']['tmp_name']);
     $path_parts = pathinfo($_FILES['upl']['name']);
     $mainName = preg_replace("/[^A-Za-z0-9]/", "", cleanString($path_parts['filename']));
-    $filename = uniqid($mainName . "_", true);
+    $filename = _uniqid($mainName . "_", true);
     $videos_id = 0;
     if (!empty($_FILES['upl']['videoId'])) {
         $videos_id = $_FILES['upl']['videoId'];

--- a/view/userChannelArtUploadInclude.php
+++ b/view/userChannelArtUploadInclude.php
@@ -1,5 +1,5 @@
 <?php
-$caUid = 'ChannelArt_' . uniqid();
+$caUid = 'ChannelArt_' . _uniqid();
 ?>
 <style>
     #custom-handle {

--- a/view/userLogin.php
+++ b/view/userLogin.php
@@ -211,7 +211,7 @@ if (empty($_COOKIE) && get_browser_name() !== 'Other (Unknown)') {
                 //include $value;
             } elseif (is_array($value)) {
                 $loginCount++;
-                $uid = uniqid();
+                $uid = _uniqid();
                 $oauthURL = "{$global['webSiteRootURL']}login?type={$value['parameters']->type}&redirectUri=" . ($_GET['redirectUri'] ?? "");
                 $loginBtnLabel = "<span class=\"{$value['parameters']->icon}\"></span> {$value['parameters']->type}";
                 if (!empty($value['dataObject']->buttonLabel)) {

--- a/view/userPhotoUploadInclude.php
+++ b/view/userPhotoUploadInclude.php
@@ -2,7 +2,7 @@
 $finalWidth = 150;
 $finalHeight = 150;
 $screenWidth = 150;
-$caUid = 'Photo_' . uniqid();
+$caUid = 'Photo_' . _uniqid();
 ?>
 <div class="form-group" id="<?php echo $caUid; ?>">
     <?php


### PR DESCRIPTION
uniqid() provides time-based unique idenfitiers. In order to avoid collisions, it waits for time to elapse. Depending on PHP version, this is done by sleeping or by polling the gettimeofday() system call, both approach being rather inefficient. uniqid() may take a few dozen of milliseconds to return, and it is called very often to build a page.

AVideo implements _uniqid() which provides random-based unique identifiers. This change replace uniqid() calls by _uniqid() to improve performances.