### PR TITLE
No need for eval() here.

### DIFF
--- a/plugin/Plugin.abstract.php
+++ b/plugin/Plugin.abstract.php
@@ -276,7 +276,7 @@ abstract class PluginAbstract {
         // nested access (e.g. "server->value") is truly required, in which case
         // sanitize with a strict regex before passing.
         $object = $this->getDataObject();
-        eval("\$object->$parameterName = \$value;");
+        $object->{$parameterName} = $value;
         return $this->setDataObject($object);
     }
 


### PR DESCRIPTION
No need for `eval()` here. Interpolation syntax can be used to achieve the same goal of setting the value of `$value` to the property named by `$parameterName` of the object at `$object`.

*See:*
<img width="670" height="90" alt="Untitled" src="https://github.com/user-attachments/assets/233e27a4-e701-4603-9302-be0243553d86" />

There are several other occurrences of `eval()` in the same file, and more elsewhere in the codebase, but the goal seems slightly different at some of those others calls, or the construction of some of those specific `eval()` calls a little more complex, so, to keep this pull request reasonably simple and easier to review, it modifies only this one, specific, singular `eval()` call.

Where appropriate, at your own discretion, the change could be used as an example for how to get rid of some of the other unnecessary `eval()` calls elsewhere in the codebase (but of course, where this strategy does/doesn't work will depend on the context and exact goals of those calls).